### PR TITLE
Error in celery worker

### DIFF
--- a/server/celery_app.py
+++ b/server/celery_app.py
@@ -1,6 +1,6 @@
 import json
 import os
-
+import eventlet
 import traceback
 
 from celery import Celery
@@ -26,6 +26,8 @@ from src.utils.file import get_ner_file
 
 app = Flask(__name__)
 CORS(app)
+
+eventlet.monkey_patch()
 
 CELERY_BROKER_URL = os.environ.get('CELERY_BROKER_URL', 'redis://ocr-redis-1:6379'),
 CELERY_RESULT_BACKEND = os.environ.get('CELERY_RESULT_BACKEND', 'redis://ocr-redis-1:6379')


### PR DESCRIPTION
Applied eventlet.monkey_patch() in celery_app.py to resolve the "2 RLock(s) were not greened" error.