### PR TITLE
Load component classes at start of files

### DIFF
--- a/website/src/App.js
+++ b/website/src/App.js
@@ -17,6 +17,18 @@ import KeyboardArrowUpRoundedIcon from '@mui/icons-material/KeyboardArrowUpRound
 import KeyboardArrowDownRoundedIcon from '@mui/icons-material/KeyboardArrowDownRounded';
 
 
+const Notification = loadComponent('Notification', 'Notifications');
+const VersionsMenu = loadComponent('Form', 'VersionsMenu');
+const LogsMenu = loadComponent('Form', 'LogsMenu');
+const FileExplorer = loadComponent('FileSystem', 'FileSystem');
+const PrivateFileExplorer = loadComponent('PrivateSession', 'PrivateFileSystem');
+// const EditPage = loadComponent('EditPage', 'EditPage');
+// const EditPage2 = loadComponent('EditPage2', 'EditPage');
+// const EditPage = loadComponent('EditPage3', 'EditPage');
+const EditPagePopUp = loadComponent('EditPage3', 'EditPagePopUp');
+const ESPage = loadComponent('ElasticSearchPage', 'ESPage');
+
+const TooltipIcon = loadComponent("TooltipIcon", "TooltipIcon");
 
 /**
  * About Versioning:
@@ -229,16 +241,16 @@ function App() {
 
         changeFolderFromPath(folder_name) {
             var current_folder = this.state.currentFolder;
-    
+
             // Remove the last element of the path until we find folder_name
             while (current_folder[current_folder.length - 1] !== folder_name) {
                 current_folder.pop();
             }
-    
+
             this.setState({
-                currentFolder: current_folder,  
+                currentFolder: current_folder,
                 fileSystemMode: true,
-                editingMenu: false, 
+                editingMenu: false,
                 layoutMenu: false,
             });
 
@@ -265,21 +277,7 @@ function App() {
         }
 
         render() {
-            const Notification = loadComponent('Notification', 'Notifications');
-            const VersionsMenu = loadComponent('Form', 'VersionsMenu');
-            const LogsMenu = loadComponent('Form', 'LogsMenu');
-            const FileExplorer = loadComponent('FileSystem', 'FileSystem');
-            const PrivateFileExplorer = loadComponent('PrivateSession', 'PrivateFileSystem');
-            // const EditPage = loadComponent('EditPage', 'EditPage');
-            // const EditPage2 = loadComponent('EditPage2', 'EditPage');
-            // const EditPage = loadComponent('EditPage3', 'EditPage');
-            const EditPagePopUp = loadComponent('EditPage3', 'EditPagePopUp');
-            const ESPage = loadComponent('ElasticSearchPage', 'ESPage');
-
-            const TooltipIcon = loadComponent("TooltipIcon", "TooltipIcon");
-
-            var buttonsDisabled = this.getPrivateSession() !== null || !this.state.fileSystemMode || this.state.layoutMenu || this.state.editingMenu;
-
+            const buttonsDisabled = this.state.searchMenu || this.state.layoutMenu || this.state.editingMenu;
             return (
                 <Box className="App" sx={{height: '100vh'}}>
                     <Notification message={""} severity={"success"} ref={this.successNot}/>
@@ -316,7 +314,7 @@ function App() {
                             >
                                 Sessão Privada
                             </Button>
-                            
+
                             <Button
                                 disabled={buttonsDisabled}
                                 variant="contained"
@@ -348,7 +346,7 @@ function App() {
 
                                         if (!this.state.fileSystemMode && !this.state.editingMenu && index > 0)
                                             return null;
-                                        
+
                                         if (folderDepth > 3 && index === 1) {
                                             return (
                                                 <Box sx={{display: "flex", flexDirection: "row", lineHeight: "2rem"}}>
@@ -418,12 +416,12 @@ function App() {
                                     </Button>
                                     : null
                                 }
-                                
+
                             </Box>
                         </Box>
 
-                        
-                        
+
+
                         <Box sx={{display: "flex", flexDirection: "row", lineHeight: "2rem"}}>
                             <Button
                                 disabled={buttonsDisabled}
@@ -511,7 +509,7 @@ function App() {
                                             top: "5.5rem",
                                             p: "0rem 1rem",
                                             width: "8rem",
-                                            
+
                                         }}
                                     >
                                         {

--- a/website/src/Components/EditPage3/Geral/ConfirmLeave.js
+++ b/website/src/Components/EditPage3/Geral/ConfirmLeave.js
@@ -7,6 +7,7 @@ import IconButton from '@mui/material/IconButton';
 import CloseRoundedIcon from '@mui/icons-material/CloseRounded';
 
 import loadComponent from '../../../utils/loadComponents';
+const Notification = loadComponent('Notification', 'Notifications');
 
 const style = {
     position: 'absolute',
@@ -49,8 +50,6 @@ class ConfirmLeave extends React.Component {
     }
 
     render() {
-        const Notification = loadComponent('Notification', 'Notifications')
-
         return (
             <Box>
                 <Notification message={""} severity={"success"} ref={this.successNot}/>

--- a/website/src/Components/EditPage3/Geral/EditPagePopUp.js
+++ b/website/src/Components/EditPage3/Geral/EditPagePopUp.js
@@ -24,6 +24,8 @@ import loadComponent from '../../../utils/loadComponents';
 
 import { Button } from '@mui/material';
 
+const CorpusDropdown = loadComponent('Dropdown', 'CorpusDropdown');
+
 const style = {
     position: 'absolute',
     top: '50%',
@@ -61,8 +63,8 @@ class Word extends React.Component {
             id={this.state.id}
             className={`${this.state.cleanText}`}
             style={{
-                margin: "0px 2px", 
-                display: "inline-block", 
+                margin: "0px 2px",
+                display: "inline-block",
                 fontSize: "14px",
                 backgroundColor: (false) ? "#ffd700" : "transparent",
                 borderRadius: "5px",
@@ -140,18 +142,18 @@ class EditPagePopUp extends React.Component {
     }
 
     toggleOpen() {
-        this.setState({ 
-            open: !this.state.open, 
-            currentPage: 1, 
-            selectedWordBox: null, 
+        this.setState({
+            open: !this.state.open,
+            currentPage: 1,
+            selectedWordBox: null,
             selectedWord: "",
             selectedWordIndex: 0,
-            parentNode: null, 
-            coordinates: null, 
-            editingText: "", 
-            imageHeight: this.state.baseImageHeight, 
-            addLineMode: false, 
-            removeLineMode: false 
+            parentNode: null,
+            coordinates: null,
+            editingText: "",
+            imageHeight: this.state.baseImageHeight,
+            addLineMode: false,
+            removeLineMode: false
         });
     }
 
@@ -171,14 +173,14 @@ class EditPagePopUp extends React.Component {
             var contents = data["doc"].sort((a, b) =>
                 (a["page_number"] > b["page_number"]) ? 1 : -1
             )
-            
+
             var sortedWords = this.orderWords(data["words"]);
-    
+
             var newCorpusList = [];
             data["corpus"].forEach((item) => {
                 newCorpusList.push({"name": item, "code": item});
             });
-    
+
             this.setState({totalPages: pages, loading: false, contents: contents, words_list: sortedWords, corpusOptions: newCorpusList});
         });
     }
@@ -208,9 +210,9 @@ class EditPagePopUp extends React.Component {
      * Used to zoom and change pages (text changes accordingly)
      */
     changePage(diff) {
-        
+
         this.setState({
-            currentPage: this.state.currentPage + diff, 
+            currentPage: this.state.currentPage + diff,
             selectedWord: "",
             selectedWordIndex: 0,
             selectedWordBox: null,
@@ -220,7 +222,7 @@ class EditPagePopUp extends React.Component {
     }
 
     firstPage() {
-        
+
         this.setState({
             currentPage: 1,
             selectedWord: "",
@@ -233,7 +235,7 @@ class EditPagePopUp extends React.Component {
 
     lastPage() {
             this.setState({
-            currentPage: this.state.totalPages, 
+            currentPage: this.state.totalPages,
             selectedWord: "",
             selectedWordIndex: 0,
             selectedWordBox: null,
@@ -243,7 +245,7 @@ class EditPagePopUp extends React.Component {
     }
 
     imageToScreenCoordinates(x, y) {
-        
+
         var image = this.image.current;
 
         var ratioX = image.naturalWidth / image.offsetWidth;
@@ -259,7 +261,7 @@ class EditPagePopUp extends React.Component {
     }
 
     showImageHighlight(e, box) {
-        
+
         var topCorner = this.imageToScreenCoordinates(box[0], box[1]);
         var bottomCorner = this.imageToScreenCoordinates(box[2], box[3]);
 
@@ -274,7 +276,7 @@ class EditPagePopUp extends React.Component {
     }
 
     zoom(delta) {
-        
+
         var newHeight = this.state.imageHeight * (1 + delta * 0.4);
 
         if (newHeight < this.state.baseImageHeight) {
@@ -290,7 +292,7 @@ class EditPagePopUp extends React.Component {
      */
 
     requestSyntax() {
-        
+
         this.setState({ loadingSintax: true });
         fetch(process.env.REACT_APP_API_URL + 'check-sintax', {
             method: 'POST',
@@ -312,7 +314,7 @@ class EditPagePopUp extends React.Component {
     }
 
     updateSyntax(words) {
-        
+
         var words_list = this.state.words_list;
         Object.entries(words).forEach(([key, value]) => {
             words_list[key]["syntax"] = value;
@@ -329,7 +331,7 @@ class EditPagePopUp extends React.Component {
         /**
          * Generate all possible combinations of words
          */
-        
+
         var word = words.splice(0, 1)[0];
         var totalCombinations = [];
 
@@ -371,7 +373,7 @@ class EditPagePopUp extends React.Component {
          * Find the combination that minimizes the difference between the previous text and the new text
          */
 
-        
+
 
         // Infinite
         // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Infinity?retiredLocale=pt-PT
@@ -401,7 +403,7 @@ class EditPagePopUp extends React.Component {
     }
 
     splitWordsByLines(words, coordinates) {
-        
+
         if (coordinates.length === 1) return [words];
 
         var separation = [];
@@ -416,9 +418,9 @@ class EditPagePopUp extends React.Component {
 
         return bestCombination;
     }
-    
+
     updateText(sectionIndex, lineIndex, wordIndex) {
-        
+
         var wordsList = this.state.words_list;
 
         var contents = this.state.contents;
@@ -430,7 +432,7 @@ class EditPagePopUp extends React.Component {
 
         var coordinates = line[wordIndex]["coordinates"];
         var combination = this.splitWordsByLines(words, coordinates);
-        
+
         var newWords = [];
 
         initial_text.split(" ").forEach((item) => {
@@ -502,7 +504,7 @@ class EditPagePopUp extends React.Component {
     }
 
     updateInputSize() {
-        
+
         var text = this.state.editingText;
         var parentNode = this.state.parentNode;
         var children = parentNode.children;
@@ -520,7 +522,7 @@ class EditPagePopUp extends React.Component {
     }
 
     getSelectedText() {
-        
+
         if (typeof window.getSelection !== "undefined") {
             // Get the range and make the all word selected
             if (window.getSelection().toString().length === 0) return null;
@@ -590,13 +592,13 @@ class EditPagePopUp extends React.Component {
             this.setState({contents: contents, inputSize: text.length});
         }
     }
-    
+
     /**
      * LINE FUNCTIONS
      * Add and remove new lines (\n)
      */
     addLine(sectionIndex, lineIndex, wordIndex) {
-        
+
         var contents = this.state.contents;
         var section = [...contents[this.state.currentPage - 1]["content"][sectionIndex]];
         var line = section[lineIndex];
@@ -611,7 +613,7 @@ class EditPagePopUp extends React.Component {
     }
 
     removeLine(sectionIndex, lineIndex) {
-        
+
         var contents = this.state.contents;
         var section = [...contents[this.state.currentPage - 1]["content"][sectionIndex]];
 
@@ -650,9 +652,9 @@ class EditPagePopUp extends React.Component {
     /**
      * WORD LIST FUNCTIONS
      * Handle the words list and actions
-     */  
+     */
     cleanWord(word) {
-        
+
         var punctuation = "!\"#$%&'()*+, -./:;<=>?@[\\]^_`{|}~«»—";
         while (word !== "") {
             if (punctuation.includes(word[0])) {
@@ -674,7 +676,7 @@ class EditPagePopUp extends React.Component {
     }
 
     cleanWordSelection() {
-        
+
         var words = document.getElementsByClassName(this.selectedWord);
 
         for (var i = 0; i < words.length; i++) {
@@ -684,10 +686,10 @@ class EditPagePopUp extends React.Component {
     }
 
     getScrollValue(word, count = 0) {
-        
+
         // var words = [];
         var words = document.getElementsByClassName(word);
-    
+
         var middleHeight = window.innerHeight / 2;
 
         var wordHeight = null;
@@ -698,7 +700,7 @@ class EditPagePopUp extends React.Component {
             if (count === 0) {
                 chosenWord = wordComponent;
             }
-            
+
             count -= 1;
             wordComponent.style.backgroundColor = "#ffd700";
         }
@@ -713,12 +715,12 @@ class EditPagePopUp extends React.Component {
     }
 
     goToNextOccurrence(word) {
-        
-        
+
+
         // var word = this.state.selectedWord;
         var index = Math.max(0, this.state.selectedWordIndex);
         var pages = this.state.words_list[word]["pages"];
-        
+
         var newPage = pages[index];
         var count = pages.slice(0, index).reduce((acc, value) => value === newPage ? acc + 1 : acc, 0);
 
@@ -749,7 +751,7 @@ class EditPagePopUp extends React.Component {
      * Send to the server the new text and structure
      */
     saveChanges() {
-        
+
         fetch(process.env.REACT_APP_API_URL + 'submit-text', {
             method: 'POST',
             headers: {
@@ -778,10 +780,7 @@ class EditPagePopUp extends React.Component {
      * Render the component
      */
     render() {
-        
-        const CorpusDropdown = loadComponent('Dropdown', 'CorpusDropdown');
-
-        var incorrectSyntax = Object.keys(this.state.words_list).filter((item) => !this.state.words_list[item]["syntax"]);
+        const incorrectSyntax = Object.keys(this.state.words_list).filter((item) => !this.state.words_list[item]["syntax"]);
         this.wordsIndex = {};
 
         return (
@@ -807,14 +806,14 @@ class EditPagePopUp extends React.Component {
                                             sx={{
                                                 position: 'relative',
                                                 width: `${window.innerWidth * 0.9 * 0.4}px`,
-                                                overflow: 'scroll', 
+                                                overflow: 'scroll',
                                                 border: '1px solid grey',
                                                 height: `${this.state.baseImageHeight}px`
                                             }}
                                         >
                                             <img
                                                 ref={this.image}
-                                                src={this.state.contents[this.state.currentPage - 1]["page_url"]} 
+                                                src={this.state.contents[this.state.currentPage - 1]["page_url"]}
                                                 alt="Imagem da pagina"
                                                 style={{
                                                     display: 'block',
@@ -879,7 +878,7 @@ class EditPagePopUp extends React.Component {
                                             <span style={{margin: "0px 10px"}}>
                                                 Página {this.state.currentPage} / {this.state.totalPages}
                                             </span>
-                                            
+
                                             <IconButton
                                                 disabled={this.state.currentPage === this.state.totalPages}
                                                 sx={{marginLeft: "10px", p: 0}}
@@ -924,7 +923,7 @@ class EditPagePopUp extends React.Component {
                                                 marginLeft: "10px",
                                                 width: this.state.wordsMode ? `${window.innerWidth * 0.9 * 0.6 - 352}px` : `${window.innerWidth * 0.9 * 0.6 - 70}px`,
                                                 height: `${this.state.baseImageHeight}px`,
-                                                overflowY: 'scroll', 
+                                                overflowY: 'scroll',
                                                 overflowX: 'wrap',
                                                 border: '1px solid grey',
                                                 paddingLeft: "10px",
@@ -982,7 +981,7 @@ class EditPagePopUp extends React.Component {
                                                                             return <>
                                                                                 {
                                                                                     this.state.addLineMode && wordIndex !== 0 && this.state.hoveredId === id
-                                                                                    ? <IconButton 
+                                                                                    ? <IconButton
                                                                                         sx={{p: 0.1, m: 0, backgroundColor: "#0000ff88", ml: 1, "&:hover": {backgroundColor: "#0000ffdd"}}}
                                                                                         onClick={() => this.addLine(sectionIndex, lineIndex, wordIndex)}
                                                                                     >
@@ -997,13 +996,13 @@ class EditPagePopUp extends React.Component {
                                                                                     overlay={this}
                                                                                     text={word["text"]}
                                                                                     id={id}
-                                                                                    box={word["box"]}  
-                                                                                    cleanText={word["clean_text"]}   
+                                                                                    box={word["box"]}
+                                                                                    cleanText={word["clean_text"]}
                                                                                 />
 
                                                                                 {
                                                                                     this.state.removeLineMode && wordIndex === line.length - 1 && (lineIndex !== section.length - 1 || sectionIndex !== this.state.contents[this.state.currentPage - 1]["content"].length - 1)
-                                                                                    ? <IconButton 
+                                                                                    ? <IconButton
                                                                                         sx={{p: 0.1, m: 0, ml: 1, backgroundColor: "#ff000088", "&:hover": {backgroundColor: "#ff0000dd"}}}
                                                                                         onClick={() => this.removeLine(sectionIndex, lineIndex)}
                                                                                     >
@@ -1020,7 +1019,7 @@ class EditPagePopUp extends React.Component {
                                                         }
                                                     </Box>;
                                                 })
-                                                
+
                                             }
                                         </Box>
 
@@ -1036,10 +1035,10 @@ class EditPagePopUp extends React.Component {
                                             padding: "0px 10px"
                                         }}>
                                             <p style={{fontSize: "18px", margin: "10px 0px 0px 0px"}}><b>Palavras</b></p>
-                                            <CorpusDropdown 
-                                                ref={this.corpusSelect} 
-                                                options={this.state.corpusOptions} 
-                                                choice={this.state.corpusChoice} 
+                                            <CorpusDropdown
+                                                ref={this.corpusSelect}
+                                                options={this.state.corpusOptions}
+                                                choice={this.state.corpusChoice}
                                             />
 
                                             <Box sx={{display: "flex", flexDirection: "row", justifyContent: "center", alignItems: "center"}}>
@@ -1217,20 +1216,20 @@ class EditPagePopUp extends React.Component {
 
                                         <Button
                                             style={{border: '1px solid black', height: "25px", marginLeft: "10px", textTransform: "none"}}
-                                            
-                                            variant="contained" 
-                                            color="success" 
-                                            onClick={() => this.saveChanges()} 
+
+                                            variant="contained"
+                                            color="success"
+                                            onClick={() => this.saveChanges()}
                                             startIcon={<SaveIcon />
                                         }>
                                             Guardar
                                         </Button>
                                     </Box>
-                                </Box> 
+                                </Box>
 
                             </Box>
                         }
-                        
+
 
                         <IconButton sx={crossStyle} aria-label="close" onClick={() => this.toggleOpen()}>
                             <CloseRoundedIcon />

--- a/website/src/Components/EditPage3/Geral/PageItem.js
+++ b/website/src/Components/EditPage3/Geral/PageItem.js
@@ -4,6 +4,8 @@ import Box from '@mui/material/Box';
 import addLine from "../../../static/addLine.svg"
 import removeLine from "../../../static/removeLine.svg"
 import loadComponent from '../../../utils/loadComponents.js';
+const TooltipIcon = loadComponent('TooltipIcon', 'TooltipIcon');
+const PageDisplayer = loadComponent('Displayer', 'PageDisplayer');
 
 class WordItem extends React.Component {
     constructor(props) {
@@ -52,7 +54,7 @@ class WordItem extends React.Component {
             >
                 {
                     this.state.changingMode
-                    ? <input 
+                    ? <input
                         style={{
                             width: `${this.state.text.length}ch`
                         }}
@@ -67,7 +69,7 @@ class WordItem extends React.Component {
                         onBlur={() => this.afterUpdate()}
                         autoFocus
                     />
-                    : <span 
+                    : <span
                         style={{
                             padding: "0px 3px",
                             fontSize: "13px"
@@ -121,8 +123,6 @@ export default class PageItem extends React.Component {
     }
 
     buildComponents() {
-        var TooltipIcon = loadComponent('TooltipIcon', 'TooltipIcon');
-
         var components = [];
         var refs = [];
 
@@ -154,7 +154,7 @@ export default class PageItem extends React.Component {
                             key={s + " " + l + " " + (l + 1 === section.length)}
                             padding={0}
                             icon={
-                                <img 
+                                <img
                                     style={{width: '1.2rem'}} src={l + 1 === section.length ? removeLine : addLine} alt="New Line"
                                 />
                             }
@@ -192,8 +192,6 @@ export default class PageItem extends React.Component {
     }
 
     render() {
-        const PageDisplayer = loadComponent('Displayer', 'PageDisplayer')
-
         return (
             <Box sx={{display: 'flex', flexDirection: 'row', mb: '1rem'}}>
                 <Box sx={{textAlign: 'center'}}>

--- a/website/src/Components/EditingMenu/Geral/EditingMenu.js
+++ b/website/src/Components/EditingMenu/Geral/EditingMenu.js
@@ -23,6 +23,11 @@ import RemoveLineIcon from '../../../static/removeLine.svg';
 import loadComponent from '../../../utils/loadComponents';
 import { CircularProgress } from '@mui/material';
 
+const CorpusDropdown = loadComponent('Dropdown', 'CorpusDropdown');
+const Notification = loadComponent('Notification', 'Notifications');
+const ConfirmLeave = loadComponent('EditPage3', 'ConfirmLeave');
+const ZoomingTool = loadComponent('ZoomingTool', 'ZoomingTool');
+
 class Word extends React.Component {
     constructor(props) {
         super(props);
@@ -59,7 +64,7 @@ class Word extends React.Component {
     }
 }
 
-export default class EditingMenu extends React.Component {
+class EditingMenu extends React.Component {
     constructor(props) {
         super(props);
         this.state = {
@@ -143,14 +148,14 @@ export default class EditingMenu extends React.Component {
             var contents = data["doc"].sort((a, b) =>
                 (a["page_number"] > b["page_number"]) ? 1 : -1
             )
-            
+
             var sortedWords = this.orderWords(data["words"]);
-    
+
             var newCorpusList = [];
             data["corpus"].forEach((item) => {
                 newCorpusList.push({"name": item, "code": item});
             });
-    
+
             this.setState({totalPages: pages, loading: false, contents: contents, words_list: sortedWords, corpusOptions: newCorpusList});
         });
     }
@@ -180,9 +185,9 @@ export default class EditingMenu extends React.Component {
      * Used to zoom and change pages (text changes accordingly)
      */
     changePage(diff) {
-        
+
         this.setState({
-            currentPage: this.state.currentPage + diff, 
+            currentPage: this.state.currentPage + diff,
             selectedWord: "",
             selectedWordIndex: 0,
             selectedWordBox: null,
@@ -192,7 +197,7 @@ export default class EditingMenu extends React.Component {
     }
 
     firstPage() {
-        
+
         this.setState({
             currentPage: 1,
             selectedWord: "",
@@ -205,7 +210,7 @@ export default class EditingMenu extends React.Component {
 
     lastPage() {
             this.setState({
-            currentPage: this.state.totalPages, 
+            currentPage: this.state.totalPages,
             selectedWord: "",
             selectedWordIndex: 0,
             selectedWordBox: null,
@@ -215,7 +220,7 @@ export default class EditingMenu extends React.Component {
     }
 
     imageToScreenCoordinates(x, y) {
-        
+
         var image = this.image.current;
 
         var ratioX = image.naturalWidth / image.offsetWidth;
@@ -231,7 +236,7 @@ export default class EditingMenu extends React.Component {
     }
 
     showImageHighlight(e, box) {
-        
+
         var topCorner = this.imageToScreenCoordinates(box[0], box[1]);
         var bottomCorner = this.imageToScreenCoordinates(box[2], box[3]);
 
@@ -246,7 +251,7 @@ export default class EditingMenu extends React.Component {
     }
 
     zoom(delta) {
-        
+
         var newHeight = this.state.imageHeight * (1 + delta * 0.4);
 
         if (newHeight < this.state.baseImageHeight) {
@@ -262,7 +267,7 @@ export default class EditingMenu extends React.Component {
      */
 
     requestSyntax() {
-        
+
         this.setState({ loadingSintax: true });
         fetch(process.env.REACT_APP_API_URL + 'check-sintax', {
             method: 'POST',
@@ -284,7 +289,7 @@ export default class EditingMenu extends React.Component {
     }
 
     updateSyntax(words) {
-        
+
         var words_list = this.state.words_list;
         Object.entries(words).forEach(([key, value]) => {
             words_list[key]["syntax"] = value;
@@ -301,7 +306,7 @@ export default class EditingMenu extends React.Component {
         /**
          * Generate all possible combinations of words
          */
-        
+
         var word = words.splice(0, 1)[0];
         var totalCombinations = [];
 
@@ -343,7 +348,7 @@ export default class EditingMenu extends React.Component {
          * Find the combination that minimizes the difference between the previous text and the new text
          */
 
-        
+
 
         // Infinite
         // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Infinity?retiredLocale=pt-PT
@@ -373,7 +378,7 @@ export default class EditingMenu extends React.Component {
     }
 
     splitWordsByLines(words, coordinates) {
-        
+
         if (coordinates.length === 1) return [words];
 
         var separation = [];
@@ -388,9 +393,9 @@ export default class EditingMenu extends React.Component {
 
         return bestCombination;
     }
-    
+
     updateText(sectionIndex, lineIndex, wordIndex) {
-        
+
         var wordsList = this.state.words_list;
 
         var contents = this.state.contents;
@@ -402,7 +407,7 @@ export default class EditingMenu extends React.Component {
 
         var coordinates = line[wordIndex]["coordinates"];
         var combination = this.splitWordsByLines(words, coordinates);
-        
+
         var newWords = [];
 
         initial_text.split(" ").forEach((item) => {
@@ -474,7 +479,7 @@ export default class EditingMenu extends React.Component {
     }
 
     updateInputSize() {
-        
+
         var text = this.state.editingText;
         var parentNode = this.state.parentNode;
         var children = parentNode.children;
@@ -492,7 +497,7 @@ export default class EditingMenu extends React.Component {
     }
 
     getSelectedText() {
-        
+
         if (typeof window.getSelection !== "undefined") {
             // Get the range and make the all word selected
             if (window.getSelection().toString().length === 0) return null;
@@ -562,13 +567,13 @@ export default class EditingMenu extends React.Component {
             this.setState({contents: contents, inputSize: text.length});
         }
     }
-    
+
     /**
      * LINE FUNCTIONS
      * Add and remove new lines (\n)
      */
     addLine(sectionIndex, lineIndex, wordIndex) {
-        
+
         var contents = this.state.contents;
         var section = [...contents[this.state.currentPage - 1]["content"][sectionIndex]];
         var line = section[lineIndex];
@@ -583,7 +588,7 @@ export default class EditingMenu extends React.Component {
     }
 
     removeLine(sectionIndex, lineIndex) {
-        
+
         var contents = this.state.contents;
         var section = [...contents[this.state.currentPage - 1]["content"][sectionIndex]];
 
@@ -622,9 +627,9 @@ export default class EditingMenu extends React.Component {
     /**
      * WORD LIST FUNCTIONS
      * Handle the words list and actions
-     */  
+     */
     cleanWord(word) {
-        
+
         var punctuation = "!\"#$%&'()*+, -./:;<=>?@[\\]^_`{|}~«»—";
         while (word !== "") {
             if (punctuation.includes(word[0])) {
@@ -646,7 +651,7 @@ export default class EditingMenu extends React.Component {
     }
 
     cleanWordSelection() {
-        
+
         var words = document.getElementsByClassName(this.selectedWord);
 
         for (var i = 0; i < words.length; i++) {
@@ -656,10 +661,10 @@ export default class EditingMenu extends React.Component {
     }
 
     getScrollValue(word, count = 0) {
-        
+
         // var words = [];
         var words = document.getElementsByClassName(word);
-    
+
         var middleHeight = window.innerHeight / 2;
 
         var wordHeight = null;
@@ -670,7 +675,7 @@ export default class EditingMenu extends React.Component {
             if (count === 0) {
                 chosenWord = wordComponent;
             }
-            
+
             count -= 1;
             wordComponent.style.backgroundColor = "#ffd700";
         }
@@ -685,12 +690,12 @@ export default class EditingMenu extends React.Component {
     }
 
     goToNextOccurrence(word) {
-        
-        
+
+
         // var word = this.state.selectedWord;
         var index = Math.max(0, this.state.selectedWordIndex);
         var pages = this.state.words_list[word]["pages"];
-        
+
         var newPage = pages[index];
         var count = pages.slice(0, index).reduce((acc, value) => value === newPage ? acc + 1 : acc, 0);
 
@@ -721,7 +726,7 @@ export default class EditingMenu extends React.Component {
      * Send to the server the new text and structure
      */
     saveChanges(remakeFiles = false) {
-        
+
         fetch(process.env.REACT_APP_API_URL + 'submit-text', {
             method: 'POST',
             headers: {
@@ -739,7 +744,7 @@ export default class EditingMenu extends React.Component {
                 // this.successNot.current.open();
                 this.setState({uncommittedChanges: false});
                 window.removeEventListener('beforeunload', this.preventExit);
-                
+
                 this.successNot.current.setMessage("Texto submetido com sucesso");
                 this.successNot.current.open();
 
@@ -754,10 +759,7 @@ export default class EditingMenu extends React.Component {
     }
 
     render() {
-        const CorpusDropdown = loadComponent('Dropdown', 'CorpusDropdown');
-        const Notification = loadComponent('Notification', 'Notifications');
-
-        var incorrectSyntax = Object.keys(this.state.words_list).filter((item) => !this.state.words_list[item]["syntax"]);
+        const incorrectSyntax = Object.keys(this.state.words_list).filter((item) => !this.state.words_list[item]["syntax"]);
         this.wordsIndex = {};
 
         return (
@@ -782,14 +784,14 @@ export default class EditingMenu extends React.Component {
                                     sx={{
                                         position: 'relative',
                                         width: `${2 * window.innerWidth / 5}px`,
-                                        overflow: 'scroll', 
+                                        overflow: 'scroll',
                                         border: '1px solid grey',
                                         height: `${this.state.baseImageHeight}px`
                                     }}
                                 >
                                     <img
                                         ref={this.image}
-                                        src={this.state.contents[this.state.currentPage - 1]["page_url"]} 
+                                        src={this.state.contents[this.state.currentPage - 1]["page_url"]}
                                         alt="Imagem da pagina"
                                         style={{
                                             display: 'block',
@@ -854,7 +856,7 @@ export default class EditingMenu extends React.Component {
                                     <span style={{margin: "0px 10px"}}>
                                         Página {this.state.currentPage} / {this.state.totalPages}
                                     </span>
-                                    
+
                                     <IconButton
                                         disabled={this.state.currentPage === this.state.totalPages}
                                         sx={{marginLeft: "10px", p: 0}}
@@ -899,7 +901,7 @@ export default class EditingMenu extends React.Component {
                                         ml: '1rem',
                                         width: this.state.wordsMode ? `${3 * window.innerWidth / 5 - 16*4 - 280}px` : `${3 * window.innerWidth / 5 - 16*4}px`,
                                         height: `${this.state.baseImageHeight}px`,
-                                        overflowY: 'scroll', 
+                                        overflowY: 'scroll',
                                         overflowX: 'wrap',
                                         border: '1px solid grey',
                                         paddingLeft: "10px",
@@ -957,7 +959,7 @@ export default class EditingMenu extends React.Component {
                                                                     return <>
                                                                         {
                                                                             this.state.addLineMode && wordIndex !== 0 && this.state.hoveredId === id
-                                                                            ? <IconButton 
+                                                                            ? <IconButton
                                                                                 sx={{p: 0.1, m: 0, backgroundColor: "#0000ff88", ml: 1, "&:hover": {backgroundColor: "#0000ffdd"}}}
                                                                                 onClick={() => this.addLine(sectionIndex, lineIndex, wordIndex)}
                                                                             >
@@ -972,13 +974,13 @@ export default class EditingMenu extends React.Component {
                                                                             overlay={this}
                                                                             text={word["text"]}
                                                                             id={id}
-                                                                            box={word["box"]}  
-                                                                            cleanText={word["clean_text"]}   
+                                                                            box={word["box"]}
+                                                                            cleanText={word["clean_text"]}
                                                                         />
 
                                                                         {
                                                                             this.state.removeLineMode && wordIndex === line.length - 1 && (lineIndex !== section.length - 1 || sectionIndex !== this.state.contents[this.state.currentPage - 1]["content"].length - 1)
-                                                                            ? <IconButton 
+                                                                            ? <IconButton
                                                                                 sx={{p: 0.1, m: 0, ml: 1, backgroundColor: "#ff000088", "&:hover": {backgroundColor: "#ff0000dd"}}}
                                                                                 onClick={() => this.removeLine(sectionIndex, lineIndex)}
                                                                             >
@@ -995,7 +997,7 @@ export default class EditingMenu extends React.Component {
                                                 }
                                             </Box>;
                                         })
-                                        
+
                                     }
                                 </Box>
 
@@ -1011,10 +1013,10 @@ export default class EditingMenu extends React.Component {
                                     padding: "0px 10px"
                                 }}>
                                     <p style={{fontSize: "18px", margin: "10px 0px 0px 0px"}}><b>Palavras</b></p>
-                                    <CorpusDropdown 
-                                        ref={this.corpusSelect} 
-                                        options={this.state.corpusOptions} 
-                                        choice={this.state.corpusChoice} 
+                                    <CorpusDropdown
+                                        ref={this.corpusSelect}
+                                        options={this.state.corpusOptions}
+                                        choice={this.state.corpusChoice}
                                     />
 
                                     <Box sx={{display: "flex", flexDirection: "row", justifyContent: "center", alignItems: "center"}}>
@@ -1192,10 +1194,10 @@ export default class EditingMenu extends React.Component {
 
                                 <Button
                                     style={{border: '1px solid black', height: "25px", marginLeft: "10px", textTransform: "none"}}
-                                    
-                                    variant="contained" 
-                                    color="success" 
-                                    onClick={() => this.saveChanges()} 
+
+                                    variant="contained"
+                                    color="success"
+                                    onClick={() => this.saveChanges()}
                                     startIcon={<SaveIcon />
                                 }>
                                     Guardar
@@ -1203,15 +1205,15 @@ export default class EditingMenu extends React.Component {
 
                                 <Button
                                     style={{border: '1px solid black', height: "25px", marginLeft: "10px", textTransform: "none"}}
-                                    variant="contained" 
-                                    color="success" 
-                                    onClick={() => this.saveChanges(true)} 
+                                    variant="contained"
+                                    color="success"
+                                    onClick={() => this.saveChanges(true)}
                                     startIcon={<CheckRoundedIcon />
                                 }>
                                     Terminar
                                 </Button>
                             </Box>
-                        </Box> 
+                        </Box>
 
                     </Box>
                 }
@@ -1219,3 +1221,5 @@ export default class EditingMenu extends React.Component {
         )
     }
 }
+
+export default EditingMenu;

--- a/website/src/Components/EditingMenu/Geral/PageItem.js
+++ b/website/src/Components/EditingMenu/Geral/PageItem.js
@@ -4,6 +4,8 @@ import Box from '@mui/material/Box';
 import addLine from "../../../static/addLine.svg"
 import removeLine from "../../../static/removeLine.svg"
 import loadComponent from '../../../utils/loadComponents.js';
+const TooltipIcon = loadComponent('TooltipIcon', 'TooltipIcon');
+const PageDisplayer = loadComponent('Displayer', 'PageDisplayer');
 
 class WordItem extends React.Component {
     constructor(props) {
@@ -52,7 +54,7 @@ class WordItem extends React.Component {
             >
                 {
                     this.state.changingMode
-                    ? <input 
+                    ? <input
                         style={{
                             width: `${this.state.text.length}ch`
                         }}
@@ -67,7 +69,7 @@ class WordItem extends React.Component {
                         onBlur={() => this.afterUpdate()}
                         autoFocus
                     />
-                    : <span 
+                    : <span
                         style={{
                             padding: "0px 3px",
                             fontSize: "13px"
@@ -121,8 +123,6 @@ export default class PageItem extends React.Component {
     }
 
     buildComponents() {
-        var TooltipIcon = loadComponent('TooltipIcon', 'TooltipIcon');
-
         var components = [];
         var refs = [];
 
@@ -154,7 +154,7 @@ export default class PageItem extends React.Component {
                             key={s + " " + l + " " + (l + 1 === section.length)}
                             padding={0}
                             icon={
-                                <img 
+                                <img
                                     style={{width: '1.2rem'}} src={l + 1 === section.length ? removeLine : addLine} alt="New Line"
                                 />
                             }
@@ -192,8 +192,6 @@ export default class PageItem extends React.Component {
     }
 
     render() {
-        const PageDisplayer = loadComponent('Displayer', 'PageDisplayer')
-
         return (
             <Box sx={{display: 'flex', flexDirection: 'row', mb: '1rem'}}>
                 <Box sx={{textAlign: 'center'}}>

--- a/website/src/Components/ElasticSearchPage/Geral/ESPage.js
+++ b/website/src/Components/ElasticSearchPage/Geral/ESPage.js
@@ -7,6 +7,8 @@ import Divider from '@mui/material/Divider';
 import InboxIcon from '@mui/icons-material/Inbox';
 
 import loadComponent from '../../../utils/loadComponents';
+const PageDisplayer = loadComponent('Displayer', 'PageDisplayer');
+const ChecklistDropdown = loadComponent('Dropdown', 'ChecklistDropdown');
 
 class ESItem extends React.Component {
     // This component is used to display a single page from the ElasticSearch database
@@ -18,8 +20,6 @@ class ESItem extends React.Component {
     }
 
     render() {
-        const PageDisplayer = loadComponent('Displayer', 'PageDisplayer');
-
         return (
             <Box sx={{
                 display: 'flex',
@@ -211,7 +211,6 @@ class ESPage extends React.Component {
     }
 
     render() {
-        const ChecklistDropdown = loadComponent('Dropdown', 'ChecklistDropdown');
         return (
             <Box sx={{
                 display: 'flex',

--- a/website/src/Components/FileSystem/Geral/FileRow.js
+++ b/website/src/Components/FileSystem/Geral/FileRow.js
@@ -17,6 +17,18 @@ import calculateEstimatedTime from '../../../utils/waitingTime';
 
 import { IconButton } from '@mui/material';
 
+const Notification = loadComponent('Notification', 'Notifications');
+const IconDatabaseImport = loadComponent('Icons', 'DatabaseInIcon');
+const IconDatabaseOff = loadComponent('Icons', 'DatabaseOffIcon');
+const TooltipIcon = loadComponent('TooltipIcon', 'TooltipIcon');
+const OcrIcon = loadComponent('CustomIcons', 'OcrIcon');
+const LayoutIcon = loadComponent('CustomIcons', 'LayoutIcon');
+const PdfIcon = loadComponent('CustomIcons', 'PdfIcon');
+const JsonIcon = loadComponent('CustomIcons', 'JsonIcon');
+const ZipIcon = loadComponent('CustomIcons', 'ZipIcon');
+const CsvIcon = loadComponent('CustomIcons', 'CsvIcon');
+const TxtIcon = loadComponent('CustomIcons', 'TxtIcon');
+
 export default class FileRow extends React.Component {
     constructor(props) {
         super(props);
@@ -142,18 +154,6 @@ export default class FileRow extends React.Component {
     }
 
     render() {
-        const Notification = loadComponent('Notification', 'Notifications');
-        const IconDatabaseImport = loadComponent('Icons', 'DatabaseInIcon');
-        const IconDatabaseOff = loadComponent('Icons', 'DatabaseOffIcon');
-        const TooltipIcon = loadComponent('TooltipIcon', 'TooltipIcon');
-        const OcrIcon = loadComponent('CustomIcons', 'OcrIcon');
-        const LayoutIcon = loadComponent('CustomIcons', 'LayoutIcon');
-        const PdfIcon = loadComponent('CustomIcons', 'PdfIcon');
-        const JsonIcon = loadComponent('CustomIcons', 'JsonIcon');
-        const ZipIcon = loadComponent('CustomIcons', 'ZipIcon');
-        const CsvIcon = loadComponent('CustomIcons', 'CsvIcon');
-        const TxtIcon = loadComponent('CustomIcons', 'TxtIcon');
-
         const buttonsDisabled = !(this.state.info["ocr"] === undefined || this.state.info["ocr"]["progress"] >= this.state.info["pages"])
 
         return (

--- a/website/src/Components/FileSystem/Geral/FileSystem.js
+++ b/website/src/Components/FileSystem/Geral/FileSystem.js
@@ -15,9 +15,18 @@ import SwapVertIcon from '@mui/icons-material/SwapVert';
 import { v4 as uuidv4 } from 'uuid';
 
 import loadComponent from '../../../utils/loadComponents';
+const FileRow = loadComponent('FileSystem', 'FileRow');
+const FolderRow = loadComponent('FileSystem', 'FolderRow');
+const Notification = loadComponent('Notification', 'Notifications');
+const FolderMenu = loadComponent('Form', 'FolderMenu');
+const OcrMenu = loadComponent('Form', 'OcrMenu');
+const DeleteMenu = loadComponent('Form', 'DeleteMenu');
+const LayoutMenu = loadComponent('LayoutMenu', 'LayoutMenu');
+const EditingMenu = loadComponent('EditingMenu', 'EditingMenu');
+const FullStorageMenu = loadComponent('Form', 'FullStorageMenu');
 
 const UPDATE_TIME = 15;
-const STUCK_UPDATE_TIME = 10 * 60; // 10 Minutes 
+const STUCK_UPDATE_TIME = 10 * 60; // 10 Minutes
 const validExtensions = [".pdf"];
 
 const chunkSize = 1024 * 1024 * 3; // 3 MB
@@ -71,7 +80,7 @@ class FileExplorer extends React.Component {
         .then(data => {
             var info = data["info"];
             var files = {'files': data["files"]};
-            
+
             this.setState({files: files, info: info, loading: false}, this.displayFileSystem);
         });
 
@@ -93,7 +102,7 @@ class FileExplorer extends React.Component {
                             const creationTime = new Date(value.creation.replace(/(\d{2})\/(\d{2})\/(\d{4}) (\d{2}):(\d{2}):(\d{2})/, '$3-$2-$1T$4:$5:$6'));
                             const currentTime = new Date();
                             const timeDiffMinutes = (currentTime - creationTime) / (1000 * 60);
-                        
+
                             if (timeDiffMinutes >= 10) {
                                 fetch(process.env.REACT_APP_API_URL + 'set-upload-stuck', {
                                     method: 'POST',
@@ -104,7 +113,7 @@ class FileExplorer extends React.Component {
                                         "path": path,
                                     }),
                                 })
-                                .then(response => response.json());                                
+                                .then(response => response.json());
                             }
                         }
                     }
@@ -276,12 +285,12 @@ class FileExplorer extends React.Component {
                         // Send chunks
                         var startChunk = 0;
                         var endChunk = chunkSize;
-        
+
                         for (let i = 0; i < _totalCount; i++) {
                             var chunk = fileBlob.slice(startChunk, endChunk, fileType);
                             startChunk = endChunk;
                             endChunk = endChunk + chunkSize;
-        
+
                             this.sendChunk(i, chunk, fileName, _totalCount, _fileID);
                         }
                     } else {
@@ -408,7 +417,7 @@ class FileExplorer extends React.Component {
             if (data instanceof Blob) {
                 var a = document.createElement('a');
                 a.href = URL.createObjectURL(data);
-    
+
                 a.download = path.split('/').slice(-1)[0] + '.zip';
                 a.click();
                 a.remove();
@@ -473,7 +482,7 @@ class FileExplorer extends React.Component {
         .then(data => {
             var a = document.createElement('a');
                 a.href = URL.createObjectURL(data);
-    
+
                 a.download = path.split('/').slice(-1)[0] + '.zip';
                 a.click();
                 a.remove();
@@ -630,10 +639,7 @@ class FileExplorer extends React.Component {
         /**
          * Iterate the contents of the folder and build the components
          */
-        const FileRow = loadComponent('FileSystem', 'FileRow');
-        const FolderRow = loadComponent('FileSystem', 'FolderRow');
-
-        var contents = this.sortContents(this.getPathContents());
+        const contents = this.sortContents(this.getPathContents());
         this.rowRefs = [];
 
         var items = [];
@@ -821,7 +827,7 @@ class FileExplorer extends React.Component {
                         }
                         return (
                             <Box sx={{display: "flex", flexDirection: "row"}} key={"Box" + folder}>
-                                <Button 
+                                <Button
                                     key={folder}
                                     onClick={() => this.changeFolderFromPath(folder)}
                                     style={{

--- a/website/src/Components/FileSystem/Geral/FolderRow.js
+++ b/website/src/Components/FileSystem/Geral/FolderRow.js
@@ -8,6 +8,7 @@ import FolderOpenRoundedIcon from '@mui/icons-material/FolderOpenRounded';
 import DeleteForeverIcon from '@mui/icons-material/DeleteForever';
 
 import loadComponent from '../../../utils/loadComponents';
+const TooltipIcon = loadComponent('TooltipIcon', 'TooltipIcon');
 
 export default class FolderRow extends React.Component {
     constructor(props) {
@@ -38,8 +39,6 @@ export default class FolderRow extends React.Component {
     }
 
     render() {
-        const TooltipIcon = loadComponent('TooltipIcon', 'TooltipIcon');
-
         return (
             <TableRow
                 sx={{":hover": {backgroundColor: "#f5f5f5", cursor: 'pointer'} }}

--- a/website/src/Components/Form/Geral/DeleteMenu.js
+++ b/website/src/Components/Form/Geral/DeleteMenu.js
@@ -7,6 +7,7 @@ import Button from '@mui/material/Button';
 import IconButton from '@mui/material/IconButton';
 import CloseRoundedIcon from '@mui/icons-material/CloseRounded';
 import loadComponent from '../../../utils/loadComponents';
+const Notification = loadComponent('Notification', 'Notifications');
 
 const style = {
     position: 'absolute',
@@ -85,8 +86,6 @@ class DeleteMenu extends React.Component {
     }
 
     render() {
-        const Notification = loadComponent('Notification', 'Notifications');
-
         return (
             <Box>
                 <Notification message={""} severity={"success"} ref={this.successNot}/>

--- a/website/src/Components/Form/Geral/FolderMenu.js
+++ b/website/src/Components/Form/Geral/FolderMenu.js
@@ -7,7 +7,9 @@ import TextField from '@mui/material/TextField';
 import Button from '@mui/material/Button';
 import IconButton from '@mui/material/IconButton';
 import CloseRoundedIcon from '@mui/icons-material/CloseRounded';
+
 import loadComponent from '../../../utils/loadComponents';
+const Notification = loadComponent('Notification', 'Notifications');
 
 const style = {
     position: 'absolute',
@@ -87,8 +89,6 @@ class FolderMenu extends React.Component {
     }
 
     render() {
-        const Notification = loadComponent('Notification', 'Notifications');
-
         return (
             <Box>
                 <Notification message={""} severity={"success"} ref={this.successNot}/>

--- a/website/src/Components/Form/Geral/OcrMenu.js
+++ b/website/src/Components/Form/Geral/OcrMenu.js
@@ -7,6 +7,9 @@ import Button from '@mui/material/Button';
 import IconButton from '@mui/material/IconButton';
 import CloseRoundedIcon from '@mui/icons-material/CloseRounded';
 import loadComponent from '../../../utils/loadComponents';
+const Notification = loadComponent('Notification', 'Notifications');
+const AlgoDropdown = loadComponent('Dropdown', 'AlgoDropdown');
+const ChecklistDropdown = loadComponent('Dropdown', 'ChecklistDropdown');
 
 const tesseractChoice = [{"name": "Português", "code": "por"}]
 const tesseractLangList = [
@@ -328,10 +331,6 @@ class OcrMenu extends React.Component {
     }
 
     render() {
-        const Notification = loadComponent('Notification', 'Notifications');
-        const AlgoDropdown = loadComponent('Dropdown', 'AlgoDropdown');
-        const ChecklistDropdown = loadComponent('Dropdown', 'ChecklistDropdown');
-
         return (
             <Box>
                 <Notification message={""} severity={"success"} ref={this.successNot}/>

--- a/website/src/Components/Form/Geral/PrivateSessionMenu.js
+++ b/website/src/Components/Form/Geral/PrivateSessionMenu.js
@@ -9,6 +9,7 @@ import CloseRoundedIcon from '@mui/icons-material/CloseRounded';
 import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 import ArrowForwardIcon from '@mui/icons-material/ArrowForward';
 import loadComponent from '../../../utils/loadComponents';
+const Notification = loadComponent('Notification', 'Notifications');
 
 const style = {
     position: 'absolute',
@@ -59,8 +60,6 @@ class PrivateSessionMenu extends React.Component {
     }
 
     render() {
-        const Notification = loadComponent('Notification', 'Notifications');
-
         return (
             <Box>
                 <Notification message={""} severity={"success"} ref={this.successNot}/>

--- a/website/src/Components/Header/Geral/Header.js
+++ b/website/src/Components/Header/Geral/Header.js
@@ -9,6 +9,7 @@ import KeyboardArrowDownRoundedIcon from '@mui/icons-material/KeyboardArrowDownR
 import KeyboardArrowUpRoundedIcon from '@mui/icons-material/KeyboardArrowUpRounded';
 import DeleteForeverIcon from '@mui/icons-material/DeleteForever';
 import loadComponent from '../../../utils/loadComponents';
+const TooltipIcon = loadComponent('TooltipIcon', 'TooltipIcon');
 
 export default class Header extends React.Component {
     constructor(props) {
@@ -52,9 +53,7 @@ export default class Header extends React.Component {
         });
     }
 
-    render() {        
-        const TooltipIcon = loadComponent('TooltipIcon', 'TooltipIcon');
-
+    render() {
         return (
             <Box sx={{
                 display: 'flex',
@@ -82,7 +81,7 @@ export default class Header extends React.Component {
                             style={{textDecoration: 'none'}}
                             onClick={() => {
                                     this.state.app.setState({fileSystemMode: true, editFileMode: false, filesChoice: [], algorithmChoice: [], configChoice: []})
-                                    this.state.app.redirectHome();                                                
+                                    this.state.app.redirectHome();
                                 }
                             }
                             underline="hover"
@@ -154,7 +153,7 @@ export default class Header extends React.Component {
                                 : null
                             }
 
-                            <Button sx={{mr: '1.5rem', padding: '0rem', color: '#1976d2'}} 
+                            <Button sx={{mr: '1.5rem', padding: '0rem', color: '#1976d2'}}
                                 onClick={() => this.state.app.openLogsMenu()}
                             >
                                 <AssignmentRoundedIcon sx={{mr: '0.3rem'}} />
@@ -165,7 +164,7 @@ export default class Header extends React.Component {
                         : null
                     }
                     <p>{`Versão: ${this.state.version}`}</p>
-                    <Button sx={{ml: '1.5rem', padding: '0rem', color: '#1976d2'}} 
+                    <Button sx={{ml: '1.5rem', padding: '0rem', color: '#1976d2'}}
                             onClick={() => window.open("https://docs.google.com/document/d/e/2PACX-1vR7BhM0haXd5CIyQatS22NrM44woFjChYCAaUAlqOjGAslLuF0TRPaMhjNW-dX8cxuaL86O5N_3mQMv/pub", '_blank')}
                     >
                         <HelpIcon sx={{mr: '0.3rem'}}>

--- a/website/src/Components/Header/STJ/Header.js
+++ b/website/src/Components/Header/STJ/Header.js
@@ -10,6 +10,7 @@ import DeleteForeverIcon from '@mui/icons-material/DeleteForever';
 
 import logoSTJ from '../../../static/logoSTJ.png';
 import loadComponent from '../../../utils/loadComponents';
+const TooltipIcon = loadComponent('TooltipIcon', 'TooltipIcon');
 
 export default class Header extends React.Component {
     constructor(props) {
@@ -53,9 +54,7 @@ export default class Header extends React.Component {
         });
     }
 
-    render() {        
-        const TooltipIcon = loadComponent('TooltipIcon', 'TooltipIcon');
-
+    render() {
         return (
             <Box sx={{
                 display: 'flex',
@@ -85,7 +84,7 @@ export default class Header extends React.Component {
                             underline="hover"
                         >
                             <h1 className='fancy-font'>OCR</h1>
-                        </Button>                                
+                        </Button>
                     </>
                 </Box>
 
@@ -135,7 +134,7 @@ export default class Header extends React.Component {
                                 : null
                             }
 
-                            <Button sx={{mr: '1.5rem', padding: '0rem', color: '#BA1514'}} 
+                            <Button sx={{mr: '1.5rem', padding: '0rem', color: '#BA1514'}}
                                 onClick={() => this.state.app.openLogsMenu()}
                             >
                                 <AssignmentRoundedIcon sx={{mr: '0.3rem'}} />
@@ -146,7 +145,7 @@ export default class Header extends React.Component {
                         : null
                     }
                     <p>{`Versão: ${this.state.version}`}</p>
-                    <Button sx={{ml: '1.5rem', padding: '0rem', color: '#BA1514'}} 
+                    <Button sx={{ml: '1.5rem', padding: '0rem', color: '#BA1514'}}
                             onClick={() => window.open("https://docs.google.com/document/d/e/2PACX-1vR7BhM0haXd5CIyQatS22NrM44woFjChYCAaUAlqOjGAslLuF0TRPaMhjNW-dX8cxuaL86O5N_3mQMv/pub", '_blank')}
                     >
                         <HelpIcon sx={{mr: '0.3rem'}}>

--- a/website/src/Components/LayoutMenu/Geral/LayoutMenu.js
+++ b/website/src/Components/LayoutMenu/Geral/LayoutMenu.js
@@ -15,10 +15,20 @@ import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 import DeleteRoundedIcon from '@mui/icons-material/DeleteRounded';
 import CallMergeIcon from '@mui/icons-material/CallMerge';
 import CallSplitIcon from '@mui/icons-material/CallSplit';
-
-import loadComponent from '../../../utils/loadComponents';
+import ZoomInIcon from "@mui/icons-material/ZoomIn";
+import ZoomOutIcon from "@mui/icons-material/ZoomOut";
+import FirstPageIcon from "@mui/icons-material/FirstPage";
+import KeyboardArrowLeftIcon from "@mui/icons-material/KeyboardArrowLeft";
+import KeyboardArrowRightIcon from "@mui/icons-material/KeyboardArrowRight";
+import LastPageIcon from "@mui/icons-material/LastPage";
 
 import { Checkbox, CircularProgress, Table, TableBody, TableCell, TableContainer, TableHead, TableRow } from '@mui/material';
+
+import loadComponent from '../../../utils/loadComponents';
+const LayoutImage = loadComponent('LayoutMenu', 'LayoutImage');
+const ConfirmLeave = loadComponent('EditPage3', 'ConfirmLeave');
+const Notification = loadComponent('Notification', 'Notifications');
+const ZoomingTool = loadComponent('ZoomingTool', 'ZoomingTool');
 
 export default class LayoutMenu extends React.Component {
 	constructor(props) {
@@ -93,7 +103,6 @@ export default class LayoutMenu extends React.Component {
 				method: 'GET'
 			}).then(response => { return response.json() })
 				.then(data => {
-
 					if (data["layouts"].some(e => !e["done"])) return;
 
 					var contents = data["layouts"].sort((a, b) =>
@@ -732,10 +741,6 @@ export default class LayoutMenu extends React.Component {
 	}
 
 	render() {
-		const LayoutImage = loadComponent('LayoutMenu', 'LayoutImage');
-		const ConfirmLeave = loadComponent('EditPage', 'ConfirmLeave');
-		const Notification = loadComponent('Notification', 'Notifications');
-
 		var noCheckBoxActive = false;
 		if (this.state.contents.length !== 0) {
 			noCheckBoxActive = !this.state.contents[this.state.page - 1]["boxes"].some(e => e["checked"]);

--- a/website/src/Components/PrivateSession/Geral/PrivateFileRow.js
+++ b/website/src/Components/PrivateSession/Geral/PrivateFileRow.js
@@ -5,12 +5,26 @@ import CircularProgress from '@mui/material/CircularProgress';
 import TableCell from '@mui/material/TableCell';
 import TableRow from '@mui/material/TableRow';
 import Button from '@mui/material/Button';
+import Collapse from '@mui/material/Collapse';
 
 import DeleteForeverIcon from '@mui/icons-material/DeleteForever';
 import EditIcon from '@mui/icons-material/Edit';
+import KeyboardArrowUpRoundedIcon from '@mui/icons-material/KeyboardArrowUpRounded';
+import KeyboardArrowDownRoundedIcon from '@mui/icons-material/KeyboardArrowDownRounded';
 
-import loadComponent from '../../../utils/loadComponents';
+import { IconButton } from '@mui/material';
+
 import calculateEstimatedTime from '../../../utils/waitingTime';
+import loadComponent from '../../../utils/loadComponents';
+const Notification = loadComponent('Notification', 'Notifications');
+const TooltipIcon = loadComponent('TooltipIcon', 'TooltipIcon');
+const OcrIcon = loadComponent('CustomIcons', 'OcrIcon');
+const LayoutIcon = loadComponent('CustomIcons', 'LayoutIcon');
+const PdfIcon = loadComponent('CustomIcons', 'PdfIcon');
+const JsonIcon = loadComponent('CustomIcons', 'JsonIcon');
+const ZipIcon = loadComponent('CustomIcons', 'ZipIcon');
+const CsvIcon = loadComponent('CustomIcons', 'CsvIcon');
+const TxtIcon = loadComponent('CustomIcons', 'TxtIcon');
 
 export default class FileRow extends React.Component {
     constructor(props) {
@@ -130,16 +144,6 @@ export default class FileRow extends React.Component {
     }
 
     render() {
-        const Notification = loadComponent('Notification', 'Notifications');
-        const TooltipIcon = loadComponent('TooltipIcon', 'TooltipIcon');
-        const OcrIcon = loadComponent('CustomIcons', 'OcrIcon');
-        const LayoutIcon = loadComponent('CustomIcons', 'LayoutIcon');
-        const PdfIcon = loadComponent('CustomIcons', 'PdfIcon');
-        const JsonIcon = loadComponent('CustomIcons', 'JsonIcon');
-        const ZipIcon = loadComponent('CustomIcons', 'ZipIcon');
-        const CsvIcon = loadComponent('CustomIcons', 'CsvIcon');
-        const TxtIcon = loadComponent('CustomIcons', 'TxtIcon');
-
         const buttonsDisabled = !(this.state.info["ocr"] === undefined || this.state.info["ocr"]["progress"] >= this.state.info["pages"])
 
         return (
@@ -198,7 +202,7 @@ export default class FileRow extends React.Component {
                                             </Box>
                                         </TableCell>
                                     </>
-                                    
+
                                     : this.state.info["progress"] !== 100.00
                                         ? <TableCell colSpan={4} align='center' sx={{backgroundColor: '#ffed7a', paddingTop: 1, paddingBottom: 1, borderLeft:"1px solid #aaa"}}>
                                             <Box sx={{display: 'flex', flexDirection: 'column'}}>

--- a/website/src/Components/PrivateSession/Geral/PrivateFileSystem.js
+++ b/website/src/Components/PrivateSession/Geral/PrivateFileSystem.js
@@ -9,13 +9,17 @@ import TableContainer from '@mui/material/TableContainer';
 import TableHead from '@mui/material/TableHead';
 import TableRow from '@mui/material/TableRow';
 import Paper from '@mui/material/Paper';
+
 import SwapVertIcon from '@mui/icons-material/SwapVert';
 
 import { v4 as uuidv4 } from 'uuid';
+
 import loadComponent from '../../../utils/loadComponents';
+const PrivateFileRow = loadComponent('PrivateSession', 'PrivateFileRow');
+const FolderRow = loadComponent('FileSystem', 'FolderRow');
 
 const UPDATE_TIME = 15;
-const STUCK_UPDATE_TIME = 10 * 60; // 10 Minutes 
+const STUCK_UPDATE_TIME = 10 * 60; // 10 Minutes
 
 const validExtensions = [".pdf", ".jpg", ".jpeg"];
 
@@ -81,7 +85,7 @@ class PrivateFileExplorer extends React.Component {
 
             var disabled = data[session].length !== 0;
 
-            
+
 
             this.setState({files: files, info: info, loading: false, addDisabled: disabled}, this.displayFileSystem);
         });
@@ -114,7 +118,7 @@ class PrivateFileExplorer extends React.Component {
                             const creationTime = new Date(value.creation.replace(/(\d{2})\/(\d{2})\/(\d{4}) (\d{2}):(\d{2}):(\d{2})/, '$3-$2-$1T$4:$5:$6'));
                             const currentTime = new Date();
                             const timeDiffMinutes = (currentTime - creationTime) / (1000 * 60);
-                        
+
                             if (timeDiffMinutes >= 10) {
                                 fetch(process.env.REACT_APP_API_URL + 'set-upload-stuck', {
                                     method: 'POST',
@@ -125,7 +129,7 @@ class PrivateFileExplorer extends React.Component {
                                         "path": path,
                                     }),
                                 })
-                                .then(response => response.json());                                
+                                .then(response => response.json());
                             }
                         }
                     }
@@ -161,7 +165,7 @@ class PrivateFileExplorer extends React.Component {
         files["files"] = data["files"]
         var info = data['info'];
 
-        
+
 
         this.setState({ files: files, info: info }, this.displayFileSystem);
     }
@@ -302,12 +306,12 @@ class PrivateFileExplorer extends React.Component {
                         // Send chunks
                         var startChunk = 0;
                         var endChunk = chunkSize;
-        
+
                         for (let i = 0; i < _totalCount; i++) {
                             var chunk = fileBlob.slice(startChunk, endChunk, fileType);
                             startChunk = endChunk;
                             endChunk = endChunk + chunkSize;
-        
+
                             this.sendChunk(i, chunk, fileName, _totalCount, _fileID);
                         }
                     } else {
@@ -494,9 +498,9 @@ class PrivateFileExplorer extends React.Component {
         /**
          * Get the info of the file
          */
-        
-        
-        
+
+
+
 
         return this.state.info[path];
     }
@@ -557,10 +561,7 @@ class PrivateFileExplorer extends React.Component {
         /**
          * Iterate the contents of the folder and build the components
          */
-        const PrivateFileRow = loadComponent('PrivateSession', 'PrivateFileRow');
-        const FolderRow = loadComponent('FileSystem', 'FolderRow');
-
-        var contents = this.sortContents(this.getPathContents());
+        const contents = this.sortContents(this.getPathContents());
         this.rowRefs = [];
 
         var items = [];
@@ -601,7 +602,7 @@ class PrivateFileExplorer extends React.Component {
         return (
             <TableContainer component={Paper}>
                 <Table aria-label="filesystem table" sx={{border:"1px solid #aaa"}}>
-                <TableHead>
+                    <TableHead>
                         <TableRow>
                             <TableCell sx={{borderLeft:"1px solid #aaa"}}>
                                 <Button
@@ -682,6 +683,7 @@ class PrivateFileExplorer extends React.Component {
         this.storageMenu.current.toggleOpen();
     }
 
+    /*
     checkOCRComplete() {
         let obj = this.state.info;
 
@@ -696,6 +698,7 @@ class PrivateFileExplorer extends React.Component {
         }
         return true;
     }
+    */
 
     render() {
         const Notification = loadComponent('Notification', 'Notifications');


### PR DESCRIPTION
The front-end is currently reloading some components' classes on every call to render().

This change makes the class imports happen only once at the start of the file, after the regular imports. Some additional classes are imported for compatibility with pull request https://github.com/stjiris/OCR/pull/221 and in preparation for refactoring of the interface in LayoutMenu and EditingMenu, but none of the functionality is altered.