### PR TITLE
Fix auto-segmentation and disable auto-segment for unsupported files

### DIFF
--- a/server/src/utils/image.py
+++ b/server/src/utils/image.py
@@ -221,12 +221,13 @@ def parse_image(img_path):
     # cv2.waitKey(0)
 
 def parse_images(path):
-    pdf_basename = get_file_basename(path)
-    filename = f"{path}/{pdf_basename}_0.jpg"
+    extension = path.split(".")[-1].lower()
+    page_extension = ".jpg" if extension == "pdf" else ".png" if extension == "zip" else f".{extension}"
+    basename = get_file_basename(path)
 
-    if os.path.exists(filename):
+    if os.path.exists(f"{path}/_pages"):
         # Grab all the images already in the folder
-        images = [x for x in glob.glob(f"{path}/{pdf_basename}_*.jpg") if x[-5] != "$"]
+        images = [x for x in glob.glob(f"{path}/_pages/{basename}_*{page_extension}") if x[-5] != "$"]
         sorted_images = sorted(images, key=lambda x: int(x.split('_')[-1].split('.')[0]))
 
         all_layouts = []

--- a/website/src/Components/LayoutMenu/Geral/LayoutMenu.js
+++ b/website/src/Components/LayoutMenu/Geral/LayoutMenu.js
@@ -30,6 +30,20 @@ const ConfirmLeave = loadComponent('EditingMenu', 'ConfirmLeave');
 const Notification = loadComponent('Notification', 'Notifications');
 const ZoomingTool = loadComponent('ZoomingTool', 'ZoomingTool');
 
+const cannotAutoSegment = new Set(["gif"]);
+/*
+files currently accepted by the platform that can be automatically segmented:
+application/pdf
+image/jpeg
+image/png
+image/tiff
+image/bmp
+image/webp (not listed in CV2 doc but accepted)
+image/x-portable-anymap
+image/jp2
+application/zip (pages are stored as PNG)
+*/
+
 class LayoutMenu extends React.Component {
 	constructor(props) {
 		super(props);
@@ -844,9 +858,13 @@ class LayoutMenu extends React.Component {
 							Limpar Tudo
 						</Button>
 						<Button
-							disabled={this.state.segmentLoading}
+							disabled={this.state.segmentLoading
+                                || cannotAutoSegment.has(this.props.filename.split('.').pop())}
+                            title={cannotAutoSegment.has(this.props.filename.split('.').pop())
+                                    ? "Não é possível segmentar automaticamente este formato de ficheiro." : ""}
 							variant="contained"
                             className="menuFunctionButton"
+                            style={{pointerEvents: "auto"}  /* ensures disabled button can show title */}
 							onClick={() => this.GenerateLayoutAutomatically()}
 						>
 							Segmentar automaticamente


### PR DESCRIPTION
The changes of #227 did not include updating the auto-segmentation feature for non-PDF files.

The algorithm currently used for automatically segmenting images is based on CV2, which can only read certain image formats.
Of the file types added by #227, GIF and WebP are not included in the CV2 documentation, although it does successfully read and segment WebP.

This PR generalizes the auto-segment function for the accepted file types, and disables the auto-segment button on the client web app for GIF files. The set of unsupported image types can be extended.