### PR TITLE
Adjust Layout menu style and implement zoom reset 

### DIFF
--- a/website/src/Components/EditingMenu/Geral/EditingMenu.js
+++ b/website/src/Components/EditingMenu/Geral/EditingMenu.js
@@ -90,11 +90,13 @@ class EditingMenu extends React.Component {
         this.selectedWord = "";
 
         this.leave = this.leave.bind(this);
-        this.zoomIn = this.zoomIn.bind(this);
-        this.zoomOut = this.zoomOut.bind(this);
         this.hoverWord = this.hoverWord.bind(this);
         this.showImageHighlight = this.showImageHighlight.bind(this)
         this.hideImageHighlight = this.hideImageHighlight.bind(this)
+
+        this.zoomIn = this.zoomIn.bind(this);
+        this.zoomOut = this.zoomOut.bind(this);
+        this.zoomReset = this.zoomReset.bind(this);
     }
 
     preventExit(event) {
@@ -245,6 +247,10 @@ class EditingMenu extends React.Component {
 
     zoomOut() {
         this.zoom(-1);
+    }
+
+    zoomReset() {
+        this.setState({imageZoom: 100});
     }
 
     zoom(delta) {
@@ -940,7 +946,7 @@ class EditingMenu extends React.Component {
                                 alignItems: "center",
                                 mt: "5px"
                             }}>
-                                <ZoomingTool zoomInFunc={this.zoomIn} zoomOutFunc={this.zoomOut}/>
+                                <ZoomingTool zoomInFunc={this.zoomIn} zoomOutFunc={this.zoomOut} zoomResetFunc={this.zoomReset}/>
 
                                 <Box sx={{marginLeft: "auto", marginRight: "auto"}}>
                                     <IconButton

--- a/website/src/Components/LayoutMenu/Geral/LayoutImage.js
+++ b/website/src/Components/LayoutMenu/Geral/LayoutImage.js
@@ -376,6 +376,13 @@ class LayoutImage extends React.Component {
         }, this.recreateBoxes)
     }
 
+    zoomReset() {
+        this.setState({
+            currentZoom: 1,
+            height: `${window.innerHeight - 160}px`,
+        }, this.recreateBoxes)
+    }
+
     screenToImageCoordinates(x, y) {
         const image = this.imageRef.current;
 

--- a/website/src/Components/LayoutMenu/Geral/LayoutImage.js
+++ b/website/src/Components/LayoutMenu/Geral/LayoutImage.js
@@ -4,9 +4,6 @@ import Box from '@mui/material/Box';
 import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 
 
-const height = window.innerHeight;
-const heightReduction = 250;
-
 class LayoutPreview extends React.Component {
     constructor(props) {
         super(props);
@@ -244,11 +241,10 @@ class LayoutImage extends React.Component {
         super(props);
         this.state = {
             menu: props.menu,
-            boxHeight: "450px",
-            height: "450px",
 
-            currentZoom: 1,
-            maxZoom: 4,
+            imageZoom: 100,
+            minImageZoom: 20,
+            maxImageZoom: 600,
 
             boxesCoords: props.boxesCoords,
             boxes: [],
@@ -363,24 +359,21 @@ class LayoutImage extends React.Component {
     }
 
     zoomIn() {
-        this.setState({
-            currentZoom: this.state.currentZoom + 1,
-            height: `${(height - heightReduction) * (this.state.currentZoom + 1)}px`,
-        }, this.recreateBoxes)
+        this.zoom(1);
     }
 
     zoomOut() {
-        this.setState({
-            currentZoom: this.state.currentZoom - 1,
-            height: `${(height - heightReduction) * (this.state.currentZoom - 1)}px`
-        }, this.recreateBoxes)
+        this.zoom(-1);
     }
 
     zoomReset() {
-        this.setState({
-            currentZoom: 1,
-            height: `${window.innerHeight - 160}px`,
-        }, this.recreateBoxes)
+        this.setState({imageZoom: 100}, this.recreateBoxes);
+    }
+
+    zoom(delta) {
+        let newZoom = Math.max(this.state.imageZoom + (20 * delta), this.state.minImageZoom);
+        newZoom = Math.min(newZoom, this.state.maxImageZoom);
+        this.setState({imageZoom: newZoom}, this.recreateBoxes);
     }
 
     screenToImageCoordinates(x, y) {
@@ -454,48 +447,44 @@ class LayoutImage extends React.Component {
 
     render() {
         return (
-            <Box sx={{display: 'flex', flexDirection: 'row'}}>
-                <Box ref={this.viewRef}
-                    draggable
-                    className="pageImage">
-                    <img
-                        ref={this.imageRef}
-                        src={this.props.imageURL}
-                        alt={`Página de ${this.props.imageURL}`}
-                        style={{
-                            display: 'block',
-                            marginLeft: 'auto',
-                            marginRight: 'auto',
-                            border: '1px solid black',
-                            maxHeight: `${this.state.height}`,
-                        }}
+            <Box ref={this.viewRef}
+                draggable
+                className="pageImageContainer">
+                <img
+                    ref={this.imageRef}
+                    src={this.props.imageURL}
+                    alt={`Página de ${this.props.imageURL}`}
+                    className={"pageImage"}
+                    style={{
+                        maxWidth: `${this.state.imageZoom}%`,
+                        maxHeight: `${this.state.imageZoom}%`,
+                    }}
 
-                        onDragStart={(e) => this.dragStart(e)}
-                        onDrag={(e) => this.duringDrag(e)}
-                        onDragEnd={(e) => this.dragEnd(e)}
-                        onLoad={() => this.loadBoxes()}
-                    />
+                    onDragStart={(e) => this.dragStart(e)}
+                    onDrag={(e) => this.duringDrag(e)}
+                    onDragEnd={(e) => this.dragEnd(e)}
+                    onLoad={() => this.loadBoxes()}
+                />
 
-                    {
-                        this.state.boxes.map((box) => {
-                            return box;
-                        })
-                    }
+                {
+                    this.state.boxes.map((box) => {
+                        return box;
+                    })
+                }
 
-                    {
-                        this.state.imageBoxes.map((box) => {
-                            return box;
-                        })
-                    }
+                {
+                    this.state.imageBoxes.map((box) => {
+                        return box;
+                    })
+                }
 
-                    {
-                        this.state.ignoreBoxes.map((box) => {
-                            return box;
-                        })
-                    }
+                {
+                    this.state.ignoreBoxes.map((box) => {
+                        return box;
+                    })
+                }
 
-                    <LayoutPreview ref={this.previewRef} top={100} left={50} bottom={200} right={150}/>
-                </Box>
+                <LayoutPreview ref={this.previewRef} top={100} left={50} bottom={200} right={150}/>
             </Box>
         )
     }

--- a/website/src/Components/LayoutMenu/Geral/LayoutMenu.js
+++ b/website/src/Components/LayoutMenu/Geral/LayoutMenu.js
@@ -9,14 +9,10 @@ import SaveIcon from '@mui/icons-material/Save';
 import CheckRoundedIcon from '@mui/icons-material/CheckRounded';
 import Switch from '@mui/material/Switch';
 
-import ArrowForwardIosRoundedIcon from '@mui/icons-material/ArrowForwardIosRounded';
-import ArrowBackIosRoundedIcon from '@mui/icons-material/ArrowBackIosRounded';
 import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 import DeleteRoundedIcon from '@mui/icons-material/DeleteRounded';
 import CallMergeIcon from '@mui/icons-material/CallMerge';
 import CallSplitIcon from '@mui/icons-material/CallSplit';
-import ZoomInIcon from "@mui/icons-material/ZoomIn";
-import ZoomOutIcon from "@mui/icons-material/ZoomOut";
 import FirstPageIcon from "@mui/icons-material/FirstPage";
 import KeyboardArrowLeftIcon from "@mui/icons-material/KeyboardArrowLeft";
 import KeyboardArrowRightIcon from "@mui/icons-material/KeyboardArrowRight";
@@ -909,6 +905,7 @@ class LayoutMenu extends React.Component {
 					<Box sx={{
 						display: 'flex',
 						flexDirection: 'column',
+                        width: '70%'
 					}}>
 						<Box sx={{display: "flex", flexDirection: "row"}}>
 							{
@@ -924,6 +921,7 @@ class LayoutMenu extends React.Component {
                                                    updateBoxes={this.updateBoxes}/>
 							}
 						</Box>
+
 						<Box sx={{
                             display: 'flex',
                             flexDirection: 'row',
@@ -973,7 +971,7 @@ class LayoutMenu extends React.Component {
 						</Box>
 					</Box>
 
-					<Box sx={{ display: "flex", flexDirection: "column", width: "100%", ml: '0.5rem', mr: '0.5rem' }}>
+					<Box sx={{ display: "flex", flexDirection: "column", width: "30%", ml: "1rem" }}>
 						<Box sx={{ display: "flex", flexDirection: "row", justifyContent: "space-evenly", alignItems: "center" }}>
 							<Button
 								disabled={copyDisabled}

--- a/website/src/Components/LayoutMenu/Geral/LayoutMenu.js
+++ b/website/src/Components/LayoutMenu/Geral/LayoutMenu.js
@@ -82,6 +82,7 @@ class LayoutMenu extends React.Component {
         this.leave = this.leave.bind(this);
         this.zoomIn = this.zoomIn.bind(this);
         this.zoomOut = this.zoomOut.bind(this);
+        this.zoomReset = this.zoomReset.bind(this);
 	}
 
 	preventExit(event) {
@@ -793,6 +794,10 @@ class LayoutMenu extends React.Component {
         this.image.current.zoomOut();
     }
 
+    zoomReset() {
+        this.image.current.zoomReset();
+    }
+
 	render() {
 		let noCheckBoxActive = false;
         let groupDisabled = false;
@@ -926,7 +931,7 @@ class LayoutMenu extends React.Component {
                             alignItems: 'center',
                             mt: '5px'
 						}}>
-                            <ZoomingTool zoomInFunc={this.zoomIn} zoomOutFunc={this.zoomOut}/>
+                            <ZoomingTool zoomInFunc={this.zoomIn} zoomOutFunc={this.zoomOut} zoomResetFunc={this.zoomReset}/>
 
                             <Box sx={{marginLeft: "auto", marginRight: "auto"}}>
                                 <IconButton

--- a/website/src/Components/ZoomingTool/Geral/ZoomingTool.js
+++ b/website/src/Components/ZoomingTool/Geral/ZoomingTool.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import Box from "@mui/material/Box";
 import IconButton from "@mui/material/IconButton";
+import ZoomResetIcon from "@mui/icons-material/Autorenew";
 import ZoomInIcon from "@mui/icons-material/ZoomIn";
 import ZoomOutIcon from "@mui/icons-material/ZoomOut";
 
@@ -20,6 +21,12 @@ class ZoomingTool extends React.Component {
                 </IconButton>
                 <IconButton
                     sx={{marginRight: "10px", p: 0}}
+                    onClick={() => this.props.zoomResetFunc()}
+                >
+                    <ZoomResetIcon />
+                </IconButton>
+                <IconButton
+                    sx={{marginRight: "10px", p: 0}}
                     onClick={() => this.props.zoomOutFunc()}
                 >
                     <ZoomOutIcon />
@@ -32,7 +39,8 @@ class ZoomingTool extends React.Component {
 ZoomingTool.defaultProps = {
     // functions:
     zoomInFunc: null,
-    zoomOutFunc: null
+    zoomOutFunc: null,
+    zoomResetFunc: null
 }
 
 export default ZoomingTool;


### PR DESCRIPTION
This PR updates the style of LayoutMenu's page display to work similarly to the one in EditingMenu by adjusting the ratio of the components and implementing zooming in the same way.

It also adds a simple zoom reset function to both menus, which brings the zoom value back to default.