### PR TITLE
Fix images zip not being created

### DIFF
--- a/server/celery_app.py
+++ b/server/celery_app.py
@@ -289,7 +289,7 @@ def task_page_ocr(path, filename, config, ocr_algorithm):
                 "creation": creation_date,
             }
 
-            if os.path.exists(f"{path}/_images") and os.listdir(f"{path}/images"):
+            if os.path.exists(f"{path}/_images") and os.listdir(f"{path}/_images"):
                 export_file(path, "imgs")
                 data["zip"] = {
                     "complete": True,

--- a/server/src/utils/export.py
+++ b/server/src/utils/export.py
@@ -89,7 +89,7 @@ def export_imgs(path, force_recreate = False):
     if os.path.exists(filename) and not force_recreate:
         return filename
 
-    shutil.make_archive(f"{path}/_images", "zip", path, base_dir="images")
+    shutil.make_archive(f"{path}/_images", "zip", path, base_dir="_images")
     return filename
 
 def export_txt(path, delimiter=False, force_recreate = False):


### PR DESCRIPTION
Zip archive with images identified in the layout menu is not being correctly exported due to paths in `export_imgs()` that were not changed as part of 483599325eea32ac5bb722f629264fa4d9535f1e. This PR fixes an error thrown by `os.listdir` and makes the resulting archive properly include the images.