### PR TITLE
Improve search page

### DIFF
--- a/website/src/Components/Dropdown/Geral/ChecklistDropdown.js
+++ b/website/src/Components/Dropdown/Geral/ChecklistDropdown.js
@@ -19,15 +19,13 @@ const MenuProps = {
   },
 };
 
-export default class ChecklistDropdown extends React.Component {
+class ChecklistDropdown extends React.Component {
     constructor(props) {
         super(props);
         this.state = {
             visible: true,
-            options: props.options,
             choice: props.choice,
             default: props.choice,
-            label: props.label,
             parentfunc: props.parentfunc
         }
 
@@ -57,7 +55,15 @@ export default class ChecklistDropdown extends React.Component {
         return this.state.choice.map((x) => x.code);
     }
 
+    getSelectedNames() {
+        return this.state.choice.map((x) => x.name);
+    }
+
     handleChange(event) {
+        this.setState({choice: event.target.value});
+    }
+
+    handleChange2(event) {
         /**
          * If an option is selected or disabled, update the choice list
          */
@@ -90,21 +96,25 @@ export default class ChecklistDropdown extends React.Component {
         return (
             <div>
                 {
-                    this.state.visible && <FormControl open={this.state.visible} sx={{mb: '0.3rem', mt: '0.5rem', width: '100%'}}>
-                        <InputLabel sx={{mt: '-0.45rem'}}>{this.state.label}</InputLabel>
+                    this.state.visible
+                    && <FormControl
+                        open={this.state.visible}
+                        sx={{mb: '0.3rem', mt: '0.5rem', width: '100%'}}>
+                        <InputLabel id="checklist-label" sx={{mt: '-0.45rem'}}>{this.props.label}</InputLabel>
                         <Select
                             multiple
+                            labelId="checklist-label"
                             value={this.state.choice}
                             onChange={(e) => this.handleChange(e)}
-                            input={<OutlinedInput label={this.state.label} />}
+                            onClose={this.props.onCloseFunc}
                             renderValue={(selected) => selected.map((x) => x.code).join(', ')}
                             MenuProps={MenuProps}
                             sx={{height: '2.5rem'}}
                         >
                             {
-                                this.state.options.map((variant) => (
+                                this.props.options.map((variant) => (
                                     <MenuItem key={variant.name} value={variant} sx={{height: '2.5rem'}}>
-                                        <Checkbox checked={this.state.choice.findIndex((item) => item.name === variant.name) >= 0} />
+                                        <Checkbox checked={this.state.choice.includes(variant)} />
                                         <ListItemText primary={variant.name} />
                                     </MenuItem>
                                 ))
@@ -116,3 +126,14 @@ export default class ChecklistDropdown extends React.Component {
         );
     }
 }
+
+ChecklistDropdown.defaultProps = {
+    options: [],
+    choice: [],
+    label: null,
+    // functions:
+    onCloseFunc: null,
+    parentFunc: null
+}
+
+export default ChecklistDropdown;

--- a/website/src/Components/ElasticSearchPage/Geral/ESPage.js
+++ b/website/src/Components/ElasticSearchPage/Geral/ESPage.js
@@ -59,12 +59,12 @@ class ESPage extends React.Component {
             documentList: [],
             pages: [],
             showing: [],
-            freeText: "",
+            query: "",
             documentOptions: []
         }
 
         // Filters
-        this.freeText = React.createRef();
+        this.searchBox = React.createRef();
         this.document = React.createRef();
         this.fileType = React.createRef();
         this.algorithm = React.createRef();
@@ -179,23 +179,27 @@ class ESPage extends React.Component {
         */
     }
 
+    /*
     changeText(event) {
-        /**
-         * Handle the change in the text field
-         */
-        this.setState({freeText: event.target.value}, this.search);
+        //
+        //Handle the change in the text field
+        //
+        this.setState({freeText: event.target.value});
     }
+     */
 
     search() {
         const filteredDocs = this.document.current.getSelectedNames();
-        // TODO: search com POST para mais params
+        // Cancel empty search request
+        if (this.state.query === "" && filteredDocs.length === 0) return;
+
         fetch(process.env.REACT_APP_API_URL + "search", {
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json'
             },
             body: JSON.stringify({
-                'query': this.state.freeText,
+                'query': this.state.query,
                 'docs': filteredDocs
             })
         })
@@ -207,10 +211,11 @@ class ESPage extends React.Component {
         });
     }
 
+    /*
     filterPages() {
-        /**
-         * Filter the pages based on the filters
-         */
+        //
+        //Filter the pages based on the filters
+        //
         var current_showing = [];
 
         var freeText = this.state.freeText;
@@ -241,6 +246,7 @@ class ESPage extends React.Component {
 
         this.setState({showing: current_showing});
     }
+    */
 
     render() {
         return (
@@ -265,14 +271,26 @@ class ESPage extends React.Component {
                         </Icon>
                         <p style={{fontSize: '15px'}}><b>{this.state.showing.length} Pages</b></p>
                     </Box>
-                    <TextField onChange={(e) => this.changeText(e)} ref={this.freeText} label="Pesquisar" variant='outlined' size="small" sx={{width: '100%', mb: '0.3rem'}}/>
+                    <TextField sx={{width: '100%', mb: '0.3rem'}}
+                               ref={this.searchBox}
+                               label="Pesquisar"
+                               variant='outlined'
+                               size="small"
+                               onChange={(e) => this.setState({query: e.target.value})}
+                               onBlur={() => {this.search()}}
+                               onKeyDown={(e) => {
+                                   if (e.key === "Enter") {
+                                       e.preventDefault();
+                                       this.search();
+                                   }
+                               }}
+                    />
                     <ChecklistDropdown
                         ref={this.document}
                         label={"Documento"}
                         options={this.state.documentList}
                         choice={[]}
-                        onCloseFunc={this.search}
-                        parentfunc={() => this.filterPages()}/>
+                        onCloseFunc={() => this.search()}/>
                     {/* <ChecklistDropdown parentfunc={() => this.filterPages()} ref={this.fileType} label={"Tipo de Ficheiro"} options={[]} choice={[]} />
                     <ChecklistDropdown parentfunc={() => this.filterPages()} ref={this.algorithm} label={"Algoritmo"} options={[]} choice={[]} />
                     <ChecklistDropdown parentfunc={() => this.filterPages()} ref={this.config} label={"Configuração"} options={[]} choice={[]} /> */}

--- a/website/src/Components/ElasticSearchPage/Geral/ESPage.js
+++ b/website/src/Components/ElasticSearchPage/Geral/ESPage.js
@@ -104,9 +104,9 @@ class ESPage extends React.Component {
 
     componentDidMount() {
         /**
-         * When the component is mounted, get the data from the ElasticSearch database
+         * When the component is mounted, get the list of indexed documents from the database
          */
-        fetch(process.env.REACT_APP_API_URL + "get_elasticsearch", {
+        fetch(process.env.REACT_APP_API_URL + "get-docs-list", {
             method: 'GET'
         })
         .then(response => {return response.json()})


### PR DESCRIPTION
The search page currently requests all index information and performs the filtering locally. The filtering is also a simple case-insensitive search for an exact match to the text written in the search field.

With this PR, loading the search page firstly fetches the list of indexed documents for the dropdown. The browser sends queries when pressing Enter or when clicking away from either the search field or the document dropdown, and the results include pages that contain any close matches to a word of the query in their text or in the document filename. If documents are selected in the dropdown, the search is limited to those documents. If documents are selected but the search box is empty, all pages of the selected documents are shown.

The design of the search page is altered to keep the toolbar and search components always visible and present the results in a scrollable area.