### PR TITLE
Update deployment instructions and configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,41 @@
 # OCR
 
 # Setup
-## Environment Variables for Local Testing
-```
-DEBUG=True
-ES_URL=http://localhost:9200/
-IMAGE_PREFIX=http://localhost
+## Example production `.env` file for the `website` folder
+```sh
+PUBLIC_URL = /endpoint-that-serves-website/
+GENERATE_SOURCEMAP = false
+
+REACT_APP_API_URL = /endpoint-that-serves-website/api
+REACT_APP_HEADER_STYLE = ''
+REACT_APP_ADMIN = "?perfil=admin"
 ```
 
-## `.env` file for the website
+## Example production `.env` file for the `server` folder
+```sh
+CELERY_BROKER_URL = redis://redis:6379/0
+CELERY_RESULT_BACKEND = redis://redis:6379/0
+ES_URL=http://elasticsearch:9200
+
+# IMAGE_PREFIX must be set to the same value as website's PUBLIC_URL if PUBLIC_URL is not '/' 
+FILES_PATH = _files
+PRIVATE_PATH = _files/_private_sessions
+
+FLASK_DEBUG = False
+FLASK_SECRET_KEY = something_very_long_and_complex (for example, use python's secrets.token_hex())
+FLASK_SECURITY_PASSWORD_SALT = a_big_number_for_HMAC_salt (for example, use python's secrets.SystemRandom().getrandbits(128))
 ```
-PORT=3001
-REACT_APP_API_URL='http://localhost/api/'
-REACT_APP_IMAGES_PREFIX = 'http://localhost'
+
+## Environment variables recommended for development
+```
+# website:
+PUBLIC_URL = /
+DEBUG=True
+GENERATE_SOURCEMAP = true
+REACT_APP_API_URL = /api
+
+# server:
+FLASK_DEBUG = True
 ```
 
 ## NGINX config file

--- a/compose/nginx/nginx.conf.template
+++ b/compose/nginx/nginx.conf.template
@@ -12,6 +12,11 @@ http {
             try_files $uri $uri/ /index.html;
         }
 
+        # Don't serve the shared folder directly
+        location /files/ {
+            return 404;
+        }
+
         location /api/ {
             proxy_pass http://server:5001/;
             proxy_read_timeout 1800;
@@ -30,22 +35,29 @@ http {
             client_max_body_size $CLIENT_MAX_BODY_SIZE;
         }
 
-        location /files/ {
-            return 403;
-        }
-
         location /images/ {
             alias /usr/share/nginx/html/files/;
-            try_files $uri $uri/ =403;
-        }
 
-        location /images/_private_sessions/ {
-            return 403;
+            # Don't serve private session images through this location
+            location ~* /images/_private_sessions/.* {
+                return 404;
+            }
+
+            # Serve only extensions that may be stored as document pages, from "_pages" folders
+            location ~* /_pages/.+\.(jpg|jpeg|jfif|pjpeg|pjp|png|tif|tiff|bmp|gif|webp|pnm|jp2)$ {
+                try_files $uri =404;
+            }
+            return 404;
         }
 
         location /private/ {  # TODO: secure private session images
             alias /usr/share/nginx/html/files/_private_sessions/;
-            try_files $uri $uri/ =403;
+
+            # Serve only extensions that may be stored as document pages, from "_pages" folders
+            location ~* /_pages/.+\.(jpg|jpeg|jfif|pjpeg|pjp|png|tif|tiff|bmp|gif|webp|pnm|jp2)$ {
+                try_files $uri =404;
+            }
+            return 404;
         }
     }
 }

--- a/compose/nginx/nginx.conf.template
+++ b/compose/nginx/nginx.conf.template
@@ -5,10 +5,10 @@ events {
 http {
     server {
         listen 80;
+        include /etc/nginx/mime.types;
 
         location / {
             root /usr/share/nginx/html/;
-            include /etc/nginx/mime.types;
             try_files $uri $uri/ /index.html;
         }
 
@@ -30,14 +30,22 @@ http {
             client_max_body_size $CLIENT_MAX_BODY_SIZE;
         }
 
+        location /files/ {
+            return 403;
+        }
 
         location /images/ {
-        # Remove /images/ to /files/
             alias /usr/share/nginx/html/files/;
+            try_files $uri $uri/ =403;
+        }
+
+        location /images/_private_sessions/ {
+            return 403;
         }
 
         location /private/ {  # TODO: secure private session images
             alias /usr/share/nginx/html/files/_private_sessions/;
+            try_files $uri $uri/ =403;
         }
     }
 }

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -89,8 +89,6 @@ services:
     environment:
       NGINX_ENVSUBST_OUTPUT_DIR: /etc/nginx
       CLIENT_MAX_BODY_SIZE: 200M
-      PUBLIC_URL: /ocr/
-      REACT_APP_API_URL: ./api/
     restart: unless-stopped
     networks:
       - internal-network

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -92,8 +92,6 @@ services:
     environment:
       NGINX_ENVSUBST_OUTPUT_DIR: /etc/nginx
       CLIENT_MAX_BODY_SIZE: 200M
-      PUBLIC_URL: /ocr/
-      REACT_APP_API_URL: ./api/
       NODE_ENV: development
     restart: unless-stopped
     networks:

--- a/server/celery_app.py
+++ b/server/celery_app.py
@@ -106,7 +106,7 @@ def task_prepare_file_ocr(path):
                 page = pdf[i]
                 bitmap = page.render(300 / 72)  # turn PDF page into 300 DPI bitmap
                 pil_image = bitmap.to_pil()
-                pil_image.save(f"{path}/_pages/{basename}_{i}.jpg", quality=95, dpi=(300, 300))
+                pil_image.save(f"{path}/_pages/{basename}_{i}.png", format="PNG", compress_level=6)
 
             pdf.close()
 


### PR DESCRIPTION
This PR ensures that some deployment-specific variables such as URLs should be set through an .env file rather than on the tracked docker-compose files.

Additionally, the NGINX configuration is altered to ensure files must be requested through API endpoints, and images must be requested from the /images/ and /private/ routes. Previously, any file from the shared storage could be accessed through a a path beginning  with /files/, /images/ or /private/. The /folder/ path is now entirely inaccessible, and /images/ and /private/ only serve image files contained in /_pages/ folders. 