### PR TITLE
Fix dotenv module missing from server

### DIFF
--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -12,7 +12,6 @@ services:
       FLASK_APP: app
       FLASK_ENV: production
       FLASK_DEBUG: 0
-      ES_URL: http://elasticsearch:9200
     command: /app/start
     expose:
       - "5001"  # exposed only to other services

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,6 @@ services:
       FLASK_APP: app
       FLASK_ENV: development
       FLASK_DEBUG: 1
-      ES_URL: http://elasticsearch:9200
     command: /app/start
     expose:
       - "5001"  # exposed only to other services

--- a/server/requirements/server/requirements/base.txt
+++ b/server/requirements/server/requirements/base.txt
@@ -10,3 +10,4 @@ psutil==5.9.5
 elasticsearch==8.17.1
 requests==2.32.2
 dnspython<2.6.0  #eventlet breaks with any higher version
+python-dotenv


### PR DESCRIPTION
Adds python-dotenv to server requirements, which is necessary to use .env files in place of hardcoded environment variables in docker-compose.