### PR TITLE
Upgrade python version to 3.12

### DIFF
--- a/compose/server/Dockerfile
+++ b/compose/server/Dockerfile
@@ -2,7 +2,7 @@
 # SPDX-FileCopyrightText: 2022 James R. Barlow
 # SPDX-License-Identifier: MPL-2.0
 
-FROM ubuntu:22.04 AS base
+FROM ubuntu:24.04 AS base
 
 ENV LANG=C.UTF-8
 ENV TZ=UTC
@@ -16,7 +16,8 @@ FROM base AS builder
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
   build-essential \
-  python3 \
+  python3-venv \
+  python3-pip \
   python3-dev \
   ca-certificates \
   curl
@@ -25,9 +26,10 @@ COPY . /app
 
 WORKDIR /app
 
-# Get the latest pip (Ubuntu version doesn't support manylinux2010)
-RUN \
-  curl https://bootstrap.pypa.io/get-pip.py | python3
+# Create and enable venv
+RUN python -m venv /opt/venv
+ENV VIRTUAL_ENV=/opt/venv
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
 RUN pip3 install --no-cache-dir -r requirements/server/requirements.txt
 
@@ -35,10 +37,15 @@ FROM base
 
 WORKDIR /app
 
+COPY --from=builder /opt/venv /opt/venv
 COPY --from=builder /usr/local/lib/ /usr/local/lib/
 COPY --from=builder /usr/local/bin/ /usr/local/bin/
 
 COPY --from=builder /app/ /app/
+
+# Enable venv
+ENV VIRTUAL_ENV=/opt/venv
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
 RUN sed -i 's/\r$//g' /app/start
 RUN chmod +x /app/start

--- a/compose/worker/Dockerfile
+++ b/compose/worker/Dockerfile
@@ -2,7 +2,7 @@
 # SPDX-FileCopyrightText: 2022 James R. Barlow
 # SPDX-License-Identifier: MPL-2.0
 
-FROM ubuntu:22.04 AS base
+FROM ubuntu:24.04 AS base
 
 ENV LANG=C.UTF-8
 ENV TZ=UTC
@@ -25,6 +25,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   build-essential autoconf automake libtool \
   libleptonica-dev \
   zlib1g-dev \
+  python3-venv \
+  python3-pip \
   python3-dev \
   libffi-dev \
   ca-certificates \
@@ -69,9 +71,10 @@ COPY . /app
 
 WORKDIR /app
 
-# Get the latest pip (Ubuntu version doesn't support manylinux2010)
-RUN \
-  curl https://bootstrap.pypa.io/get-pip.py | python3
+# Create and enable venv
+RUN python -m venv /opt/venv
+ENV VIRTUAL_ENV=/opt/venv
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
 RUN pip3 install --no-cache-dir -r requirements/worker/requirements.txt
 
@@ -102,10 +105,15 @@ ENV TESSDATA_PREFIX=/usr/share/tesseract-ocr/5/tessdata/
 
 WORKDIR /app
 
+COPY --from=builder /opt/venv /opt/venv
 COPY --from=builder /usr/local/lib/ /usr/local/lib/
 COPY --from=builder /usr/local/bin/ /usr/local/bin/
 
 COPY --from=builder /app/ /app/
+
+# Enable venv
+ENV VIRTUAL_ENV=/opt/venv
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
 RUN sed -i 's/\r$//g' /app/start
 RUN chmod +x /app/start

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -8,11 +8,13 @@ services:
       context: ./server
       dockerfile: ../compose/server/Dockerfile
     image: ocr-server
+    env_file: "server/.env"
     environment:
       FLASK_APP: app
       FLASK_ENV: production
       FLASK_DEBUG: 0
-      ES_URL: http://elasticsearch:9200
+      PYTHONUNBUFFERED: true
+      PYTHONDONTWRITEBYTECODE : true
     command: /app/start
     expose:
       - "5001"  # exposed only to other services
@@ -32,11 +34,13 @@ services:
       context: ./server
       dockerfile: ../compose/worker/Dockerfile
     image: ocr-worker
+    env_file: "server/.env"
     environment:
       CELERY_BROKER_URL: redis://redis:6379/0
       CELERY_RESULT_BACKEND: redis://redis:6379/0
       C_FORCE_ROOT: true
       PYTHONUNBUFFERED: true
+      PYTHONDONTWRITEBYTECODE : true
     command: celery -A celery_app.celery worker --loglevel=info --without-gossip --without-mingle --without-heartbeat -Ofair --concurrency=8 -P prefork
     volumes:
       - files_data:/app/_files
@@ -51,6 +55,7 @@ services:
     image: ocr-worker
     environment:
       CELERY_BROKER_URL: redis://redis:6379/0
+      CELERY_RESULT_BACKEND: redis://redis:6379/0
     command: celery -A celery_app.celery flower --port=5050
     expose:
       - "5050"  # exposed only to other services
@@ -89,8 +94,6 @@ services:
     environment:
       NGINX_ENVSUBST_OUTPUT_DIR: /etc/nginx
       CLIENT_MAX_BODY_SIZE: 200M
-      PUBLIC_URL: /ocr/
-      REACT_APP_API_URL: ./api/
     restart: unless-stopped
     networks:
       - internal-network

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,11 +8,13 @@ services:
       context: ./server
       dockerfile: ../compose/server/Dockerfile
     image: ocr-server
+    env_file: "server/.env"
     environment:
       FLASK_APP: app
       FLASK_ENV: development
       FLASK_DEBUG: 1
-      ES_URL: http://elasticsearch:9200
+      PYTHONUNBUFFERED: true
+      PYTHONDONTWRITEBYTECODE : true
     command: /app/start
     expose:
       - "5001"  # exposed only to other services
@@ -32,11 +34,13 @@ services:
       context: ./server
       dockerfile: ../compose/worker/Dockerfile
     image: ocr-worker
+    env_file: "server/.env"
     environment:
       CELERY_BROKER_URL: redis://redis:6379/0
       CELERY_RESULT_BACKEND: redis://redis:6379/0
       C_FORCE_ROOT: true
       PYTHONUNBUFFERED: true
+      PYTHONDONTWRITEBYTECODE : true
     command: celery -A celery_app.celery worker --loglevel=debug --without-gossip --without-mingle --without-heartbeat -Ofair -E --hostname=worker1@%h
     volumes:
       - files_data:/app/_files
@@ -92,8 +96,6 @@ services:
     environment:
       NGINX_ENVSUBST_OUTPUT_DIR: /etc/nginx
       CLIENT_MAX_BODY_SIZE: 200M
-      PUBLIC_URL: /ocr/
-      REACT_APP_API_URL: ./api/
       NODE_ENV: development
     restart: unless-stopped
     networks:

--- a/server/requirements/worker/requirements/base.txt
+++ b/server/requirements/worker/requirements/base.txt
@@ -12,7 +12,6 @@ reportlab==3.6.13
 pypdfium2==5.0.0b1
 requests==2.*
 dnspython<2.6.0  #eventlet breaks with any higher version
-python-dotenv
 #numpy<2
 #memory-profiler
 tesserocr==2.8.0

--- a/server/src/elastic_search.py
+++ b/server/src/elastic_search.py
@@ -4,7 +4,7 @@ from elasticsearch import Elasticsearch
 from src.utils.file import get_file_basename
 from src.utils.file import FILES_PATH
 
-ES_URL = environ.get("ES_URL", "http://localhost:9200/")
+ES_URL = environ.get("ES_URL", "http://elasticsearch:9200/")
 IMAGE_PREFIX = environ.get("IMAGE_PREFIX", ".")
 ES_INDEX = "jornais.0.1"
 


### PR DESCRIPTION
This PR upgrades the Python version used by `server` and `worker` from 3.10 to 3.12 by upgrading the Ubuntu version from 22.04 to 24.04. Given the warning about the risk of breaking libraries when installing packages system-wide, the scripts create virtual environments for their requirements.