### PR TITLE
Replace additional info in server response with async requests from client

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# OCR – 1.0
+# OCR – 1.1
 
 # Setup
 For a prepared server, the only required setup is the creation of `.env` files in the `website` and `server` folders. If the server is behind a proxy and must be accessed through a specific path, this path must be placed where `/path-that-serves-website/` is specified.

--- a/server/app.py
+++ b/server/app.py
@@ -589,7 +589,7 @@ def upload_file():
         or "totalCount" not in request.form):
         return bad_request("Missing file or parameter 'name', 'counter', or 'totalCount'")
 
-    path, filesystem_path, private_session, is_private = format_filesystem_path(request.form)
+    path, _ = format_path(request.form)
     file = request.files["file"]
     filename = request.form["name"]
     counter = int(request.form["counter"])
@@ -613,7 +613,7 @@ def upload_file():
 
         celery.send_task('prepare_file', kwargs={'path': target_path})
 
-        return {"success": True, "finished": True, "info": get_folder_info(target_path, private_session)}
+        return {"success": True, "finished": True}
 
     # Create a Lock to process the file
     if temp_filename not in lock_system:
@@ -648,9 +648,9 @@ def upload_file():
                 args=(target_path, filename, total_count, temp_file_path)
             ).start()
 
-            return {"success": True, "finished": True, "info": get_folder_info(target_path, private_session)}
+            return {"success": True, "finished": True}
 
-    return {"success": True, "finished": False, "info": get_folder_info(target_path, private_session)}
+    return {"success": True, "finished": False}
 
 
 @app.route("/save-config", methods=["POST"])

--- a/server/app.py
+++ b/server/app.py
@@ -563,8 +563,7 @@ def prepare_upload():
             ensure_ascii=False,
         )
 
-    return {"success": True, "filesystem": get_filesystem(filesystem_path, private_session, is_private),
-            "filename": filename}
+    return {"success": True, "filename": filename}
 
 
 def join_chunks(target_path, filename, total_count, temp_file_path):

--- a/website/src/Components/FileSystem/Geral/FileSystem.js
+++ b/website/src/Components/FileSystem/Geral/FileSystem.js
@@ -373,6 +373,11 @@ class FileExplorer extends React.Component {
             } else {
                 this.storageMenu.current.openWithMessage(data.error);
             }
+
+            // Update list of files on screen after upload of first chunk
+            if (i === 0) {
+                this.fetchFiles();
+            }
         })
         .catch(error => {
             // TODO: give feedback to user on communication error
@@ -441,7 +446,6 @@ class FileExplorer extends React.Component {
                     } else {
                         this.storageMenu.current.openWithMessage(data.error);
                     }
-                    this.fetchFiles();
                 });
             }
         });

--- a/website/src/Components/FileSystem/Geral/FileSystem.js
+++ b/website/src/Components/FileSystem/Geral/FileSystem.js
@@ -39,7 +39,7 @@ const EditingMenu = loadComponent('EditingMenu', 'EditingMenu');
 const FullStorageMenu = loadComponent('Notifications', 'FullStorageMenu');
 
 const UPDATE_TIME = 15;
-const STUCK_UPDATE_TIME = 10 * 60; // 10 Minutes
+const STUCK_UPDATE_TIME = 20 * 60; // 20 Minutes
 
 const validExtensions = ["application/pdf",
                                 "image/jpeg",
@@ -136,7 +136,6 @@ class FileExplorer extends React.Component {
 
         // functions for menus
         this.fetchFiles = this.fetchFiles.bind(this);
-        this.updateFiles = this.updateFiles.bind(this);
     }
 
     componentDidMount() {
@@ -169,7 +168,7 @@ class FileExplorer extends React.Component {
                             const currentTime = new Date();
                             const timeDiffMinutes = (currentTime - creationTime) / (1000 * 60);
 
-                            if (timeDiffMinutes >= 10) {
+                            if (timeDiffMinutes >= STUCK_UPDATE_TIME) {
                                 fetch(API_URL + '/set-upload-stuck', {
                                     method: 'POST',
                                     headers: {
@@ -187,7 +186,7 @@ class FileExplorer extends React.Component {
                         }
                     }
                 }
-                this.setState({info: info, updateCount: 0});
+                this.fetchInfo();
             });
         }, 1000 * STUCK_UPDATE_TIME);
     }
@@ -229,6 +228,11 @@ class FileExplorer extends React.Component {
             });
     }
 
+    /**
+     * Fetch updated information about existing files and metadata.
+     *
+     * Call after actions that create or delete documents/folders.
+     */
     fetchFiles() {
         axios.get(API_URL + '/files', {
             params: {
@@ -252,9 +256,15 @@ class FileExplorer extends React.Component {
     }
 
     createFetchInfoInterval() {
-        this.interval = setInterval(this.fetchInfo, 1000 * UPDATE_TIME);
+        this.infoInterval = setInterval(this.fetchInfo, 1000 * UPDATE_TIME);
     }
 
+    /**
+     * Fetch updated metadata from the server.
+     *
+     * Call occasionally for updated info,
+     * and after actions on existing files, that don't create or delete documents/folders.
+     */
     fetchInfo() {
         axios.get(API_URL + '/info', {
             params: {
@@ -276,6 +286,9 @@ class FileExplorer extends React.Component {
             });
     }
 
+    /**
+     * Update the info of each row being displayed.
+     */
     updateInfo() {
         if (this.state.ocrMenu || this.state.layoutMenu || this.state.editingMenu) return;
         if (this.state.fileOpened) {
@@ -304,15 +317,6 @@ class FileExplorer extends React.Component {
             clearInterval(this.infoInterval);
         if (this.stuckInterval)
             clearInterval(this.stuckInterval);
-    }
-
-    /**
-     * Update the files and info
-     */
-    updateFiles(data) {
-        const files = data['files'];
-        const info = data['info'];
-        this.setState({ files: files, info: info });
     }
 
     /**
@@ -1097,7 +1101,7 @@ class FileExplorer extends React.Component {
                 this.errorNot.current.openNotif(data.message);
             }
 
-            this.updateFiles(data.files);
+            this.fetchInfo();
         })
     }
 
@@ -1122,7 +1126,7 @@ class FileExplorer extends React.Component {
                 this.errorNot.current.openNotif(data.message);
             }
 
-            this.updateFiles(data.files);
+            this.fetchInfo();
         })
     }
 

--- a/website/src/Components/FileSystem/Geral/FileSystem.js
+++ b/website/src/Components/FileSystem/Geral/FileSystem.js
@@ -427,28 +427,22 @@ class FileExplorer extends React.Component {
                 }).then(response => {return response.json()})
                 .then(data => {
                     if (data['success']) {
-                        var filesystem = data["filesystem"];
-                        var info = filesystem["info"];
-                        var files = filesystem["files"];
-                        this.setState({files: files, info: info});
                         fileName = data["filename"];
 
                         // Send chunks
-                        var startChunk = 0;
-                        var endChunk = chunkSize;
-
+                        let startChunk = 0;
+                        let endChunk = chunkSize;
                         for (let i = 0; i < _totalCount; i++) {
-                            var chunk = fileBlob.slice(startChunk, endChunk, fileType);
+                            let chunk = fileBlob.slice(startChunk, endChunk, fileType);
                             startChunk = endChunk;
                             endChunk = endChunk + chunkSize;
-
                             this.sendChunk(i, chunk, fileName, _totalCount, _fileID);
                         }
                     } else {
                         this.storageMenu.current.openWithMessage(data.error);
                     }
+                    this.fetchFiles();
                 });
-
             }
         });
         el.click();

--- a/website/src/Components/OcrMenu/Geral/OcrMenu.js
+++ b/website/src/Components/OcrMenu/Geral/OcrMenu.js
@@ -319,7 +319,7 @@ class OcrMenu extends React.Component {
         const path = (this.props.sessionId + '/' + this.props.current_folder + '/' + this.props.filename).replace(/^\//, '');
         const config = this.state.usingDefault ? "default" : this.getConfig();
         axios.post(API_URL + '/save-config',
-            JSON.stringify({
+            {
                 _private: this.props._private,
                 path: path,
                 config: config,


### PR DESCRIPTION
The server is currently gathering and returning information about the file system in several endpoints, which may be unnecessary and bloat the response if the calls are being made through an API. This also implies duplicate code that increases the chance of mistakes if the functions that gather file system information are altered.

This PR ensures that the server avoids performing unnecessary work for API requests, and the client must rely on calls to `/files` and `/info` to get updated information. In the web application, this means making these calls asynchronously after receiving responses from the endpoints that previously returned file system information.