### PR TITLE
Fix API call parameter value for pytesseract engine

### DIFF
--- a/server/celery_app.py
+++ b/server/celery_app.py
@@ -239,7 +239,10 @@ def task_file_ocr(path: str, config: dict | None):
             # Build string with Tesseract run configuration
             if "engine" in config:
                 if config["engine"].lower() not in OCR_ENGINES:
-                    raise ValueError("Invalid OCR engine value", config["engine"])
+                    raise ValueError(
+                        f"Invalid OCR engine value; possible values are {OCR_ENGINES}",
+                        config["engine"],
+                    )
             else:
                 config["engine"] = default_config["engine"]
             if "lang" not in config:

--- a/server/config_files/default.json
+++ b/server/config_files/default.json
@@ -1,5 +1,5 @@
 {
-    "engine": "tesseract",
+    "engine": "pytesseract",
     "lang": ["por"],
     "outputs": ["pdf", "txt"],
     "engineMode": 3,

--- a/website/src/Components/OcrMenu/Geral/OcrMenu.js
+++ b/website/src/Components/OcrMenu/Geral/OcrMenu.js
@@ -48,9 +48,9 @@ const tesseractOutputsList = [
     { value: "xml", description: "ALTO (apenas documentos com 1 página)", disabled: true},
 ]
 
-const defaultEngine = "tesseract";
+const defaultEngine = "pytesseract";
 const engineList = [
-    { value: "tesseract", description: "PyTesseract"},
+    { value: "pytesseract", description: "PyTesseract"},
     { value: "tesserOCR", description: "TesserOCR"},
 ]
 


### PR DESCRIPTION
Updates value used by the browser client for Pytesseract, from the original "tesseract" to the new "pytesseract" expected by the server.