### PR TITLE
Adjust configurations for server deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,9 @@ For a prepared server, the only required setup is the creation of `.env` files i
 
 ## Example production `website/.env` file
 ```sh
-PUBLIC_URL = /path-that-serves-website/
-REACT_APP_API_URL = /path-that-serves-website/api
+PUBLIC_URL = https://example.com/path-that-serves-website
+REACT_APP_BASENAME = path-that-serves-website  # no forward slashes at the start or end
+REACT_APP_API_URL = path-that-serves-website/api
 GENERATE_SOURCEMAP = false
 ```
 
@@ -16,7 +17,7 @@ CELERY_BROKER_URL = redis://redis:6379/0
 CELERY_RESULT_BACKEND = redis://redis:6379/0
 ES_URL = http://elasticsearch:9200/
 
-# IMAGE_PREFIX must be set to the same value as website's PUBLIC_URL if PUBLIC_URL is not '/' 
+# IMAGE_PREFIX must be set to the same value as website's PUBLIC_URL if PUBLIC_URL is not '/'
 FILES_PATH = _files
 PRIVATE_PATH = _files/_private_sessions
 
@@ -25,7 +26,7 @@ FLASK_SECRET_KEY = something_very_long_and_complex # (for example, use python's 
 FLASK_SECURITY_PASSWORD_SALT = a_big_number_for_HMAC_salt # (for example, use python's secrets.SystemRandom().getrandbits(128))
 
 ADMIN_EMAIL = put_admin_email_or_username@here.spam
-ADMIN_PASSWORD = put_admin_password_here
+ADMIN_PASS = put_admin_password_here
 ```
 
 ## Environment variables recommended for local development

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ GENERATE_SOURCEMAP = false
 
 ## Example production `server/.env` file
 ```sh
+APP_BASENAME = path-that-serves-website  # no forward slashes at the start or end
 CELERY_BROKER_URL = redis://redis:6379/0
 CELERY_RESULT_BACKEND = redis://redis:6379/0
 ES_URL = http://elasticsearch:9200/
@@ -32,12 +33,13 @@ ADMIN_PASS = put_admin_password_here
 ## Environment variables recommended for local development
 ```sh
 # website:
-PUBLIC_URL = /
+PUBLIC_URL = http://localhost
 DEBUG = True
 GENERATE_SOURCEMAP = true
 REACT_APP_API_URL = /api
 
 # server:
+APP_BASENAME = ""
 FLASK_DEBUG = True
 ```
 

--- a/compose/nginx/nginx.conf.template
+++ b/compose/nginx/nginx.conf.template
@@ -5,6 +5,7 @@ events {
 }
 
 http {
+    limit_req_zone $binary_remote_addr zone=login:10m rate=1r/s;
     # ssl_session_cache   shared:SSL:10m;
     # ssl_session_timeout 10m;
 
@@ -28,7 +29,7 @@ http {
 
         keepalive_timeout   70;
 
-        server_name localhsot;
+        server_name localhost;
 
         add_header X-Content-Type-Options "nosniff";
 
@@ -44,6 +45,17 @@ http {
 
         location /api/ {
             proxy_pass            http://server:5001/;
+            proxy_read_timeout    1800;
+            proxy_connect_timeout 1800;
+            proxy_send_timeout    1800;
+            send_timeout          1800;
+            client_max_body_size  $CLIENT_MAX_BODY_SIZE;
+        }
+
+        # Rate-limit the login route
+        location /api/account/login {
+            limit_req zone=login;
+            proxy_pass            http://server:5001/account/login;
             proxy_read_timeout    1800;
             proxy_connect_timeout 1800;
             proxy_send_timeout    1800;

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -36,8 +36,6 @@ services:
     image: ocr-worker
     env_file: "server/.env"
     environment:
-      CELERY_BROKER_URL: redis://redis:6379/0
-      CELERY_RESULT_BACKEND: redis://redis:6379/0
       C_FORCE_ROOT: true
       PYTHONUNBUFFERED: true
       PYTHONDONTWRITEBYTECODE : true
@@ -55,11 +53,10 @@ services:
 
   flower:
     image: ocr-worker
+    env_file: "server/.env"
     environment:
-      CELERY_BROKER_URL: redis://redis:6379/0
-      CELERY_RESULT_BACKEND: redis://redis:6379/0
       FLOWER_UNAUTHENTICATED_API: true  # authentication managed through Flask
-    command: celery -A celery_app.celery flower --port=5050 --url_prefix="admin/flower" --enable_events=False
+    command: bash -c "celery -A celery_app.celery flower --port=5050 --url_prefix=$$APP_BASENAME\"/admin/flower\" --enable_events=False"
     expose:
       - "5050"  # exposed only to other services
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,8 +36,6 @@ services:
     image: ocr-worker
     env_file: "server/.env"
     environment:
-      CELERY_BROKER_URL: redis://redis:6379/0
-      CELERY_RESULT_BACKEND: redis://redis:6379/0
       C_FORCE_ROOT: true
       PYTHONUNBUFFERED: true
       PYTHONDONTWRITEBYTECODE : true
@@ -55,11 +53,10 @@ services:
 
   flower:
     image: ocr-worker
+    env_file: "server/.env"
     environment:
-      CELERY_BROKER_URL: redis://redis:6379/0
-      CELERY_RESULT_BACKEND: redis://redis:6379/0
       FLOWER_UNAUTHENTICATED_API: true  # authentication managed through Flask
-    command: celery -A celery_app.celery flower --port=5050 --url_prefix="admin/flower" --enable_events=False
+    command: bash -c "celery -A celery_app.celery flower --port=5050 --url_prefix=$$APP_BASENAME\"/admin/flower\" --enable_events=False"
     expose:
       - "5050"  # exposed only to other services
     depends_on:

--- a/website/src/App.js
+++ b/website/src/App.js
@@ -406,7 +406,7 @@ function App() {
 
     return (
         <LocalizationProvider dateAdapter={AdapterDayjs} adapterLocale="pt">
-            <BrowserRouter basename={process.env.REACT_APP_PUBLIC_URL}>
+            <BrowserRouter basename={`/${process.env.REACT_APP_BASENAME}`}>
                 <Routes>
                     <Route index element={<WrappedForm />} />
                     <Route path="/session/:sessionId" element={<WrappedForm />} />

--- a/website/src/Components/Admin/Geral/Dashboard.js
+++ b/website/src/Components/Admin/Geral/Dashboard.js
@@ -102,7 +102,7 @@ const Dashboard = (props) => {
                     Configurar Predefinições OCR
                 </Button>
 
-                <Link to="/admin/flower" target="_blank" rel="noreferrer">
+                <Link to="/admin/flower/" target="_blank" rel="noreferrer">
                     <Button
                         variant="contained"
                         className="adminMenuButton"


### PR DESCRIPTION
This PR fixes an incorrect usage of dict.get(), adds REACT_APP_BASENAME and APP_BASENAME as environment variables required for a deployment under a specific path, and rate-limits the login endpoint to reduce the effectiveness of brute-force attacks against the admin page.