### PR TITLE
Correct config verification for tesserOCR and fix indexing feature

### DIFF
--- a/server/src/engines/ocr_pytesseract.py
+++ b/server/src/engines/ocr_pytesseract.py
@@ -1,64 +1,15 @@
 import os
-from enum import Enum
 from tempfile import NamedTemporaryFile
 
 from lxml import etree
 from lxml import html
 from pytesseract import pytesseract
+from src.utils.enums_tesseract import ENGINE_MODES
+from src.utils.enums_tesseract import LANGS
+from src.utils.enums_tesseract import OUTPUTS
+from src.utils.enums_tesseract import SEGMENT_MODES
+from src.utils.enums_tesseract import THRESHOLD_METHODS
 from src.utils.parse_hocr import parse_hocr
-
-
-class LANGS(Enum):
-    DEU = "deu"
-    SPA = "spa"
-    FRA = "fra"
-    ENG = "eng"
-    POR = "por"
-    EQU = "equ"
-    OSD = "osd"
-
-
-class ENGINE_MODES(Enum):
-    TESSERACT_ONLY = 0
-    LSTM_ONLY = 1
-    TESSERACT_LSTM_COMBINED = 2
-    DEFAULT = 3  # Default
-
-
-class SEGMENT_MODES(Enum):
-    OSD_ONLY = 0
-    AUTO_OSD = 1
-    AUTO_ONLY = 2
-    AUTO = 3  # Default
-    SINGLE_COLUMN = 4
-    SINGLE_BLOCK_VERT_TEXT = 5
-    SINGLE_BLOCK = 6
-    SINGLE_LINE = 7
-    SINGLE_WORD = 8
-    CIRCLE_WORD = 9
-    SINGLE_CHAR = 10
-    SPARSE_TEXT = 11
-    SPARSE_TEXT_OSD = 12
-    RAW_LINE = 13
-    COUNT = 14
-
-
-class THRESHOLD_METHODS(Enum):
-    OTSU = 0  # DEFAULT
-    LEPTONICA = 1
-    SAUVOLA = 2
-
-
-class OUTPUTS(Enum):
-    PDF_INDEXED = "pdf_indexed"
-    PDF = "pdf"
-    TXT = "txt"
-    TXT_DELIMITED = "txt_delimited"
-    CSV = "csv"
-    NER = "ner"
-    HOCR = "hocr"
-    ALTO_XML = "xml"
-
 
 TESSERACT_OUTPUTS = (
     "hocr",

--- a/server/src/engines/ocr_pytesseract.py
+++ b/server/src/engines/ocr_pytesseract.py
@@ -104,16 +104,17 @@ def _run_and_get_multiple_output(
 def get_structure(
     page,
     lang: str,
-    config_str: str = "",
-    output_types: list[str] = None,
+    config: str = "",
+    doc_path: str = "",  # not used, added for consistent parameter names with tesserOCR
+    output_types: list[str] | None = None,
     segment_box=None,
 ):
     if segment_box:
         raw_results = _get_segment_hocr(
-            page, lang, config_str, segment_coordinates=segment_box
+            page, lang, config, segment_coordinates=segment_box
         )
     else:
-        raw_results = _get_hocr(page, lang, config_str, extensions=output_types)
+        raw_results = _get_hocr(page, lang, config, extensions=output_types)
 
     hocr = etree.fromstring(raw_results["hocr"], html.XHTMLParser())
     lines = parse_hocr(hocr, segment_box)

--- a/server/src/engines/ocr_tesserocr.py
+++ b/server/src/engines/ocr_tesserocr.py
@@ -1,3 +1,5 @@
+from lxml import etree
+from lxml import html
 from PIL import Image
 from PIL import ImageEnhance
 from PIL import ImageFilter
@@ -13,6 +15,24 @@ from tesserocr import PyTessBaseAPI
 
 api = PyTessBaseAPI(init=False)
 
+# TesserOCR's ProcessPage() (singular) cannot output a valid PDF.
+# TODO: obtain a PDF directly by using tesserOCR's ProcessPages() (plural), which takes a file path instead of PIL image.
+
+TESSERACT_OUTPUTS = (
+    "hocr",
+    # "pdf",
+    "tsv",
+    "txt",
+    "xml",
+)
+
+EXTENSION_TO_VAR = {
+    "hocr": "tessedit_create_hocr",
+    # "pdf": "tessedit_create_pdf",
+    "tsv": "tessedit_create_tsv",
+    "txt": "tessedit_create_txt",
+    "xml": "tessedit_create_alto",
+}
 
 INT_TO_OEM = {  # Cannot directly convert int to OEM due to TesserOCR _Enum type
     0: OEM.TESSERACT_ONLY,
@@ -54,12 +74,21 @@ def preprocess_image(image):
     return image
 
 
-def get_structure(page, config, segment_box=None):
+def get_structure(
+    page,
+    lang: str,
+    config: dict | str,
+    doc_path: str = "",
+    output_types: list[str] | None = None,
+    segment_box=None,
+):
     """
     Extract text and layout structure from a page or a segment.
 
     :param page: The PIL image of the page.
+    :param lang: The string of languages to use
     :param config: OCR configuration options (dict).
+    :param output_types: List of output types to auto-generate if the document being OCR'd only has one page.
     :param segment_box: Optional bounding box for a segment (left, top, right, bottom) or list of boxes.
     :return: Extracted text structure in the form of lines and words.
     """
@@ -74,14 +103,15 @@ def get_structure(page, config, segment_box=None):
         }
 
     api.InitFull(
-        lang=config.get("lang", "por"),
+        lang=config.get("lang", lang),
         oem=config.get("oem", INT_TO_OEM[3]),
         psm=config.get("psm", INT_TO_PSM[3]),
     )
     # TODO: receive other variables
 
-    api.SetImage(page)
+    raw_results_paths = []
     if segment_box:
+        api.SetImage(page)
         if isinstance(segment_box, list):  # Batch multiple segments
             results = []
             for box in segment_box:
@@ -105,10 +135,26 @@ def get_structure(page, config, segment_box=None):
             api.SetRectangle(**coords)
             hocr = api.GetHOCRText(0)
     else:
-        hocr = api.GetHOCRText(0)
+        if output_types is None or len(output_types) == 0:
+            output_types = ["hocr"]
+        elif "hocr" not in output_types:
+            output_types.append("hocr")
+
+        output_base = f"{doc_path}/_export/_temp"
+        extensions = [ext for ext in output_types if ext in TESSERACT_OUTPUTS]
+        for ext in extensions:
+            api.SetVariable(EXTENSION_TO_VAR[ext], "true")
+            raw_results_paths.append(f"{output_base}.{ext}")
+        api.ProcessPage(
+            outputbase=output_base, image=page, page_index=0, filename="test1"
+        )
+        hocr = etree.parse(f"{output_base}.hocr", html.XHTMLParser())
 
     api.End()
-    return parse_hocr(hocr, segment_box)
+
+    lines = parse_hocr(hocr, segment_box)
+
+    return lines, raw_results_paths
 
 
 def verify_params(config):

--- a/server/src/utils/enums_tesseract.py
+++ b/server/src/utils/enums_tesseract.py
@@ -1,0 +1,53 @@
+from enum import Enum
+
+
+class LANGS(Enum):
+    DEU = "deu"
+    SPA = "spa"
+    FRA = "fra"
+    ENG = "eng"
+    POR = "por"
+    EQU = "equ"
+    OSD = "osd"
+
+
+class ENGINE_MODES(Enum):
+    TESSERACT_ONLY = 0
+    LSTM_ONLY = 1
+    TESSERACT_LSTM_COMBINED = 2
+    DEFAULT = 3  # Default
+
+
+class SEGMENT_MODES(Enum):
+    OSD_ONLY = 0
+    AUTO_OSD = 1
+    AUTO_ONLY = 2
+    AUTO = 3  # Default
+    SINGLE_COLUMN = 4
+    SINGLE_BLOCK_VERT_TEXT = 5
+    SINGLE_BLOCK = 6
+    SINGLE_LINE = 7
+    SINGLE_WORD = 8
+    CIRCLE_WORD = 9
+    SINGLE_CHAR = 10
+    SPARSE_TEXT = 11
+    SPARSE_TEXT_OSD = 12
+    RAW_LINE = 13
+    COUNT = 14
+
+
+class THRESHOLD_METHODS(Enum):
+    OTSU = 0  # DEFAULT
+    LEPTONICA = 1
+    SAUVOLA = 2
+
+
+class OUTPUTS(Enum):
+    PDF_INDEXED = "pdf_indexed"
+    PDF = "pdf"
+    TXT = "txt"
+    TXT_DELIMITED = "txt_delimited"
+    CSV = "csv"
+    NER = "ner"
+    HOCR = "hocr"
+    ALTO_XML = "xml"

--- a/server/src/utils/export.py
+++ b/server/src/utils/export.py
@@ -73,7 +73,7 @@ def export_imgs(path, force_recreate=False):
     if os.path.exists(filename) and not force_recreate:
         return filename
 
-    shutil.make_archive(f"{path}/_export/_images", "zip", path, base_dir="images")
+    shutil.make_archive(f"{path}/_export/_images", "zip", path, base_dir="_images")
     return filename
 
 


### PR DESCRIPTION
This PR fixes an error when verifying the received configuration for tesserOCR due to its custom implementation of Enum which prevents direct comparisons with integers. The verification now does not error.

The changes also allow retrieving direct results from Tesseract on the OCR of a single-page document, as long as it is processed without any layout boxes.

The handling of indexed documents is also corrected, so that:
- Requesting for a document to be removed from an index now switches the `indexed` flag to `false` in its `_data.json` if no data was found in the index.
- Requesting OCR of a file that was already processed and indexed removes the results that are currently indexed. The user must index the new results.

## Note
The implemented `ocr_tesserocr` module does not yet pass advanced parameters to the OCR engine, aside from language, OEM and PSM. This PR's changes only involve using a different API call to produce result files in the case that a document has a  singular page and no layout boxes were created.