### PR TITLE
Implement OCR requests for entire folder

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -837,9 +837,9 @@ def request_ocr():
 
     if multiple:
         files = [
-            f"{path}/{f}"  # path is safe, 'f' obtained by server
-            for f in os.listdir(path)
-            if os.path.isdir(os.path.join(path, f))
+            f.path
+            for f in os.scandir(path)
+            if f.is_dir() and get_data(f"{f.path}/_data.json")["type"] == "file"
         ]
     else:
         files = [path]

--- a/server/app.py
+++ b/server/app.py
@@ -626,7 +626,14 @@ def prepare_upload():
 
     target = safe_join(path, filename)
 
+    # Create document folder and subfolders
     os.mkdir(target)
+    os.mkdir(target + "/_export")
+    os.mkdir(target + "/_images")
+    os.mkdir(target + "/_layouts")
+    os.mkdir(target + "/_ocr_results")
+    os.mkdir(target + "/_pages")
+
     with open(f"{target}/_data.json", "w", encoding="utf-8") as f:
         json.dump(
             {

--- a/server/celery_app.py
+++ b/server/celery_app.py
@@ -618,6 +618,7 @@ def task_page_ocr(
                     config=config,
                     doc_path=path,
                     output_types=output_types,
+                    single_page=True,
                 )
             else:
                 json_d, _ = ocr_engine.get_structure(

--- a/server/src/engines/ocr_pytesseract.py
+++ b/server/src/engines/ocr_pytesseract.py
@@ -44,8 +44,14 @@ def _get_segment_hocr(page, lang: str, config_str: str, segment_coordinates):
     )
 
 
-def _get_hocr(page, lang: str, config_str: str, extensions: list[str] = None):
-    if extensions is None:
+def _get_hocr(
+    page,
+    lang: str,
+    config_str: str,
+    extensions: list[str] = None,
+    single_page: bool = False,
+):
+    if not single_page or extensions is None:
         extensions = ["hocr"]
     return _run_and_get_multiple_output(
         page, lang=lang, extensions=extensions, config_str=config_str
@@ -108,13 +114,16 @@ def get_structure(
     doc_path: str = "",  # not used, added for consistent parameter names with tesserOCR
     output_types: list[str] | None = None,
     segment_box=None,
+    single_page: bool = False,
 ):
     if segment_box:
         raw_results = _get_segment_hocr(
             page, lang, config, segment_coordinates=segment_box
         )
     else:
-        raw_results = _get_hocr(page, lang, config, extensions=output_types)
+        raw_results = _get_hocr(
+            page, lang, config, extensions=output_types, single_page=single_page
+        )
 
     hocr = etree.fromstring(raw_results["hocr"], html.XHTMLParser())
     lines = parse_hocr(hocr, segment_box)

--- a/server/src/utils/file.py
+++ b/server/src/utils/file.py
@@ -513,12 +513,12 @@ def get_data(file):
         return json.loads(text)
 
 
-def get_doc_len(file):
+def get_doc_len(file) -> int:
     with open(file, encoding="utf-8") as f:
         text = f.read()
         if text == "":
-            return {}
-        return json.loads(text)["pages"]
+            return -1
+        return int(json.loads(text)["pages"])
 
 
 def update_json_file(file, data):

--- a/website/src/App.css
+++ b/website/src/App.css
@@ -199,6 +199,13 @@ cannot be styled with props, interferes with functioning of Autocomplete
     text-align: center;
 }
 
+.actionsCell-inner {
+    display: flex;
+    flex-direction: row;
+    justify-content: center;
+    align-items: center;
+}
+
 .MuiTableCell-root.stateCell {
     width: 8%;
     text-align: center;

--- a/website/src/Components/FileSystem/Geral/DocumentRow.js
+++ b/website/src/Components/FileSystem/Geral/DocumentRow.js
@@ -4,7 +4,6 @@ import CircularProgress from '@mui/material/CircularProgress';
 
 import TableCell from '@mui/material/TableCell';
 import TableRow from '@mui/material/TableRow';
-import Button from '@mui/material/Button';
 
 import DeleteForeverIcon from '@mui/icons-material/DeleteForever';
 import EditIcon from '@mui/icons-material/Edit';
@@ -148,7 +147,7 @@ class DocumentRow extends React.Component {
                         </>
                         : <>
                             <TableCell className="explorerCell actionsCell" align='center'>
-                                <Box sx={{display: 'flex', flexDirection: 'row', justifyContent: 'center', alignItems: 'center'}}>
+                                <Box className="actionsCell-inner">
                                     <TooltipIcon
                                         key={"OCR " + this.props.name}
                                         disabled={buttonsDisabled && this.state.info["ocr"]["exceptions"] === undefined}
@@ -284,6 +283,7 @@ DocumentRow.defaultProps = {
     deleteItem: null,
     editText: null,
     performOCR: null,
+    configureOCR: null,
     indexFile: null,
     removeIndexFile: null,
     createLayout: null

--- a/website/src/Components/FileSystem/Geral/FileSystem.js
+++ b/website/src/Components/FileSystem/Geral/FileSystem.js
@@ -981,6 +981,8 @@ class FileExplorer extends React.Component {
                         name={key}
                         info={this.getInfo(key)}
                         enterFolder={this.enterFolder}
+                        performOCR={this.performOCR}
+                        configureOCR={this.configureOCR}
                         deleteItem={this.deleteItem}
                     />
                 )
@@ -1203,7 +1205,7 @@ class FileExplorer extends React.Component {
                                sessionId={this.props._private ? this.props.sessionId : ""}
                                current_folder={this.props.current_folder}
                                filename={this.props.current_file_name}
-                               isFolder={this.props.isFolder}
+                               isFolder={this.props.ocrTargetIsFolder}
                                isSinglePage={this.props.ocrTargetIsSinglePage}
                                customConfig={this.props.customConfig}
                                setCurrentCustomConfig={this.props.setCurrentCustomConfig}

--- a/website/src/Components/FileSystem/Geral/FolderRow.js
+++ b/website/src/Components/FileSystem/Geral/FolderRow.js
@@ -6,9 +6,12 @@ import TableRow from '@mui/material/TableRow';
 
 import FolderOpenRoundedIcon from '@mui/icons-material/FolderOpenRounded';
 import DeleteForeverIcon from '@mui/icons-material/DeleteForever';
+import SettingsIcon from '@mui/icons-material/Settings';
+import SettingsSuggestIcon from '@mui/icons-material/SettingsSuggest';
 
 import loadComponent from '../../../utils/loadComponents';
 const TooltipIcon = loadComponent('TooltipIcon', 'TooltipIcon');
+const OcrIcon = loadComponent('CustomIcons', 'OcrIcon');
 
 class FolderRow extends React.Component {
     constructor(props) {
@@ -26,12 +29,26 @@ class FolderRow extends React.Component {
         this.props.enterFolder(this.props.name);
     }
 
+    performOCR(e, usingCustomConfig) {
+        e.stopPropagation();
+        const customConfig = usingCustomConfig ? this.state.info?.["config"] : null;
+        this.props.performOCR(this.props.name, true, true, customConfig);
+    }
+
+    configureOCR(e, usingCustomConfig) {
+        e.stopPropagation();
+        const customConfig = usingCustomConfig ? this.state.info?.["config"] : null;
+        this.props.configureOCR(this.props.name, true, false, customConfig);
+    }
+
     delete(e) {
         e.stopPropagation();
         this.props.deleteItem(this.props.name);
     }
 
     render() {
+        const buttonsDisabled = false;
+        const usingCustomConfig = this.state.info?.["config"] && this.state.info["config"] !== "default";
         return (
             <TableRow className="explorerRow"
                 sx={{":hover": {backgroundColor: "#f5f5f5", cursor: 'pointer'} }}
@@ -49,12 +66,36 @@ class FolderRow extends React.Component {
                 </TableCell>
 
                 <TableCell className="explorerCell actionsCell" align='center'>
-                    <TooltipIcon
-                        className="negActionButton"
-                        message="Apagar"
-                        clickFunction={(e) => this.delete(e)}
-                        icon={<DeleteForeverIcon/>}
-                    />
+                    <Box className="actionsCell-inner">
+                        <TooltipIcon
+                            key={"OCR " + this.props.name}
+                            disabled={buttonsDisabled && this.state.info["ocr"]["exceptions"] === undefined}
+                            className="actionButton"
+                            message="Fazer OCR"
+                            clickFunction={(e) => this.performOCR(e, usingCustomConfig)}
+                            icon={<OcrIcon/>}
+                        />
+
+                        <TooltipIcon
+                            key={"Config " + this.props.name}
+                            disabled={buttonsDisabled && this.state.info["ocr"]["exceptions"] === undefined}
+                            className={"actionButton"
+                                // highlight custom configs with different color
+                                + (usingCustomConfig
+                                    ? " altColor"
+                                    : "")}
+                            message="Configurar OCR"
+                            clickFunction={(e) => this.configureOCR(e, usingCustomConfig)}
+                            icon={usingCustomConfig ? <SettingsSuggestIcon/> : <SettingsIcon/>}
+                        />
+
+                        <TooltipIcon
+                            className="negActionButton"
+                            message="Apagar"
+                            clickFunction={(e) => this.delete(e)}
+                            icon={<DeleteForeverIcon/>}
+                        />
+                    </Box>
                 </TableCell>
 
                 <TableCell className="explorerCell stateCell" align='center'>
@@ -84,6 +125,8 @@ FolderRow.defaultProps = {
     name: null,
     // functions:
     enterFolder: null,
+    performOCR: null,
+    configureOCR: null,
     deleteItem: null
 }
 

--- a/website/src/Components/FileSystem/Geral/StaticFileRow.js
+++ b/website/src/Components/FileSystem/Geral/StaticFileRow.js
@@ -40,7 +40,7 @@ class StaticFileRow extends React.Component {
                 </TableCell>
 
                 <TableCell className="explorerCell staticActionsCell">
-                    <Box sx={{display: 'flex', flexDirection: 'row', justifyContent: 'center', alignItems: 'center'}}>
+                    <Box className="actionsCell-inner">
                         <TooltipIcon
                             className="actionButton"
                             message="Transferir"

--- a/website/src/Components/Form/Geral/OcrPopup.js
+++ b/website/src/Components/Form/Geral/OcrPopup.js
@@ -120,6 +120,9 @@ class OcrPopup extends React.Component {
                 }
 
                 this.closeMenu(this.props.submitCallback);
+            })
+            .catch(err => {
+               this.errorNot.current.openNotif("Não foi possível realizar o pedido.")
             });
     }
 

--- a/website/src/Components/OcrMenu/Geral/OcrMenu.js
+++ b/website/src/Components/OcrMenu/Geral/OcrMenu.js
@@ -58,9 +58,9 @@ class OcrMenu extends React.Component {
             fetchingPreset: false,  // true if selected preset has been fetched
         }
 
-        // Enable options restricted to single-page
-        tesseractOutputsList[tesseractOutputsList.length-2]["disabled"] = !this.props.isSinglePage;  // hOCR output
-        tesseractOutputsList[tesseractOutputsList.length-1]["disabled"] = !this.props.isSinglePage;  // ALTO output
+        // Disable options restricted to single-page if configuring for multi-page documents
+        tesseractOutputsList[tesseractOutputsList.length-2]["disabled"] = !this.props.isSinglePage && !this.props.isFolder;  // hOCR output
+        tesseractOutputsList[tesseractOutputsList.length-1]["disabled"] = !this.props.isSinglePage && !this.props.isFolder;  // ALTO output
 
         this.confirmLeave = React.createRef();
         this.successNot = React.createRef();

--- a/website/src/Components/OcrMenu/Geral/OcrMenu.js
+++ b/website/src/Components/OcrMenu/Geral/OcrMenu.js
@@ -274,6 +274,9 @@ class OcrMenu extends React.Component {
                 } else {
                     this.errorNot.current.openNotif("Erro inesperado ao guardar a configuração de OCR.")
                 }
+            })
+            .catch(err => {
+                this.errorNot.current.openNotif("Não foi possível guardar a configuração de OCR.");
             });
     }
 


### PR DESCRIPTION
This PR adds the following features to folders, accessible through buttons in the actions column:

- Creation of an OCR configuration to apply when requesting OCR of the folder. The output types hOCR and ALTO are available but may not apply to all of the folder's contents.

- Request OCR of all documents contained in the folder. The contents of subfolders are not considered, and this feature is intended for OCR of a single collection of documents organised at the same level.

This PR also prevents the unnecessary creation and storage in memory of OCR result files produced directly by Tesseract in the case of multi-page documents, and fixes an unintended mutation of the list of outputs that caused the hOCR to be listed even when not requested.