### PR TITLE
hotfix: avoid overwriting info about config used in OCR at export step

### DIFF
--- a/server/celery_app.py
+++ b/server/celery_app.py
@@ -710,13 +710,14 @@ def task_page_ocr(
             if n_doc_pages == 1 and raw_results:
                 export_from_existing(path, raw_results, output_types)
 
-            finish_ocr_data = {
-                "ocr": {
+            finish_ocr_data = get_data(data_file)
+            finish_ocr_data["ocr"].update(
+                {
                     "progress": len(files),
                     "size": get_ocr_size(f"{path}/_ocr_results"),
                     "creation": get_current_time(),
                 }
-            }
+            )
 
             update_json_file(data_file, finish_ocr_data)
 


### PR DESCRIPTION
Info about the configuration that was used in an OCR run was being overwritten at the final step of exporting results, causing an error when attempting to include this data in the indexing of results in elasticsearch.