### PR TITLE
Render TIFF images in the browser interface

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -24,7 +24,8 @@
         "react-icons": "^5.5.0",
         "react-router": "7.6.2",
         "react-scripts": "5.0.1",
-        "styled-components": "^6.1.17"
+        "styled-components": "^6.1.17",
+        "utif": "^3.1.0"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -17463,6 +17464,21 @@
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
       }
+    },
+    "node_modules/utif": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/utif/-/utif-3.1.0.tgz",
+      "integrity": "sha512-WEo4D/xOvFW53K5f5QTaTbbiORcm2/pCL9P6qmJnup+17eYfKaEhDeX9PeQkuyEoIxlbGklDuGl8xwuXYMrrXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "^1.0.5"
+      }
+    },
+    "node_modules/utif/node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",

--- a/website/package.json
+++ b/website/package.json
@@ -19,7 +19,8 @@
     "react-icons": "^5.5.0",
     "react-router": "7.6.2",
     "react-scripts": "5.0.1",
-    "styled-components": "^6.1.17"
+    "styled-components": "^6.1.17",
+    "utif": "^3.1.0"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/website/src/Components/EditingMenu/Geral/EditingMenu.js
+++ b/website/src/Components/EditingMenu/Geral/EditingMenu.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import UTIF from 'utif';
 
 import Box from '@mui/material/Box';
 import IconButton from '@mui/material/IconButton';
@@ -81,6 +82,7 @@ class EditingMenu extends React.Component {
     constructor(props) {
         super(props);
         this.state = {
+            loaded: false,
             contents: [],
             words_list: [],
             corpusOptions: [],
@@ -135,6 +137,12 @@ class EditingMenu extends React.Component {
         this.getContents();
     }
 
+    componentDidUpdate(prevProps, prevState, snapshot) {
+        if (!prevState.loaded && this.state.loaded) {
+            UTIF.replaceIMG();  // automatically replace TIFF <img> sources
+        }
+    }
+
     goBack() {
         if (this.state.uncommittedChanges) {
             this.confirmLeave.current.toggleOpen();
@@ -171,7 +179,13 @@ class EditingMenu extends React.Component {
                 newCorpusList.push({"name": item, "code": item});
             });
 
-            this.setState({totalPages: pages, contents: contents, words_list: sortedWords, corpusOptions: newCorpusList});
+            this.setState({
+                totalPages: pages,
+                contents: contents,
+                words_list: sortedWords,
+                corpusOptions: newCorpusList,
+                loaded: true
+            });
         });
     }
 
@@ -770,7 +784,6 @@ class EditingMenu extends React.Component {
     }
 
     render() {
-        const loaded = this.state.contents.length !== 0;
         const incorrectSyntax = Object.keys(this.state.words_list).filter((item) => !this.state.words_list[item]["syntax"]);
         return (
             <Box>
@@ -797,7 +810,7 @@ class EditingMenu extends React.Component {
                             {
                             this.state.addLineMode
                                 ? <Button
-                                    disabled={!loaded}
+                                    disabled={!this.state.loaded}
                                     color="error"
                                     variant="contained"
                                     className="menuFunctionButton"
@@ -808,7 +821,7 @@ class EditingMenu extends React.Component {
                                 </Button>
 
                                 : <Button
-                                    disabled={!loaded}
+                                    disabled={!this.state.loaded}
                                     variant="contained"
                                     className="menuFunctionButton"
                                     onClick={() => {this.setState({addLineMode: true, removeLineMode: false})}}
@@ -821,7 +834,7 @@ class EditingMenu extends React.Component {
                             {
                             this.state.removeLineMode
                                 ? <Button
-                                    disabled={!loaded}
+                                    disabled={!this.state.loaded}
                                     color="error"
                                     variant="contained"
                                     className="menuFunctionButton"
@@ -832,7 +845,7 @@ class EditingMenu extends React.Component {
                                 </Button>
 
                                 : <Button
-                                    disabled={!loaded}
+                                    disabled={!this.state.loaded}
                                     variant="contained"
                                     className="menuFunctionButton"
                                     onClick={() => {this.setState({removeLineMode: true, addLineMode: false})}}
@@ -845,7 +858,7 @@ class EditingMenu extends React.Component {
                             {
                             this.state.wordsMode
                                 ? <Button
-                                    disabled={!loaded}
+                                    disabled={!this.state.loaded}
                                     color="error"
                                     variant="contained"
                                     className="menuFunctionButton"
@@ -862,7 +875,7 @@ class EditingMenu extends React.Component {
                                     }
                                 </Button>
                                 : <Button
-                                    disabled={!loaded}
+                                    disabled={!this.state.loaded}
                                     variant="contained"
                                     className="menuFunctionButton"
                                     onClick={() => {this.setState({wordsMode: true})}}
@@ -880,7 +893,7 @@ class EditingMenu extends React.Component {
                             }
 
                             <Button
-                                disabled={!loaded}
+                                disabled={!this.state.loaded}
                                 color="success"
                                 variant="contained"
                                 className="menuFunctionButton"
@@ -891,7 +904,7 @@ class EditingMenu extends React.Component {
                             </Button>
 
                             <Button
-                                disabled={!loaded}
+                                disabled={!this.state.loaded}
                                 variant="contained"
                                 color="success"
                                 className="menuFunctionButton noMarginRight"
@@ -904,7 +917,7 @@ class EditingMenu extends React.Component {
                     </Box>
 
                     {
-                    loaded
+                    this.state.loaded
                     ? <>
                     <Box sx={{
                         display: "flex",
@@ -922,7 +935,7 @@ class EditingMenu extends React.Component {
                                     <img
                                         ref={this.imageRef}
                                         src={this.state.contents[this.state.currentPage - 1]["page_url"]}
-                                        alt="Imagem da pagina"
+                                        alt={`Imagem da página ${this.state.currentPage}`}
                                         className={"pageImage"}
                                         style={{
                                             maxWidth: `${this.state.imageZoom}%`,

--- a/website/src/Components/LayoutMenu/Geral/LayoutImage.js
+++ b/website/src/Components/LayoutMenu/Geral/LayoutImage.js
@@ -1,4 +1,6 @@
 import React from 'react';
+import UTIF from "utif";
+
 import Box from '@mui/material/Box';
 
 import ContentCopyIcon from '@mui/icons-material/ContentCopy';
@@ -256,8 +258,6 @@ class LayoutImage extends React.Component {
     constructor(props) {
         super(props);
         this.state = {
-            menu: props.menu,
-
             imageZoom: 100,
             minImageZoom: 20,
             maxImageZoom: 600,
@@ -276,7 +276,9 @@ class LayoutImage extends React.Component {
 
     componentDidMount() {
         window.addEventListener('resize', this.recreateBoxes);
+        UTIF.replaceIMG();  // automatically replace TIFF <img> sources
         this.loadBoxes();
+        //this.displayTIFF(this.props.imageURL);
     }
 
     componentWillUnmount() {
@@ -288,6 +290,34 @@ class LayoutImage extends React.Component {
             this.loadBoxes();
         }
     }
+
+    /*
+    async displayTIFF(tiffUrl) {
+        const response = await axios.get(tiffUrl, {
+            responseType: 'arraybuffer'
+        })
+        this.imgLoaded({ target: { response: response.data } })
+    }
+
+    imgLoaded(e) {
+        const ifds = UTIF.decode(e.target.response)
+        //const ifds = decode(e.target.response)
+        const _tiffs = ifds.map((ifd, index) => {
+            UTIF.decodeImage(e.target.response, ifd)
+            const rgba = UTIF.toRGBA8(ifd)
+            const canvas = document.getElementById('image-canvas')
+            canvas.width = ifd.width
+            canvas.height = ifd.height
+            const ctx = canvas.getContext('2d')
+            const img = ctx.createImageData(ifd.width, ifd.height)
+            img.data.set(rgba)
+            ctx.putImageData(img, 0, 0)
+            //if (index === 0)
+            //    document.getElementById('tiff-inner-container').appendChild(canvas)
+            return canvas
+        })
+    }
+    */
 
     createLayoutBox(ref, box, type, checked = false) {
         return <LayoutBox
@@ -399,8 +429,8 @@ class LayoutImage extends React.Component {
         const ratioX = image.naturalWidth / image.offsetWidth;
         const ratioY = image.naturalHeight / image.offsetHeight;
 
-        const domX = x - this.imageRef.current.offsetLeft;
-        const domY = y - this.imageRef.current.offsetTop;
+        const domX = x - image.offsetLeft;
+        const domY = y - image.offsetTop;
 
         const imgX = domX * ratioX;
         const imgY = domY * ratioY;
@@ -473,14 +503,13 @@ class LayoutImage extends React.Component {
     }
 
     render() {
-        console.log("Rerendering image");
         return (
             <Box ref={this.viewRef}
                 className="pageImageContainer">
                 <img
                     ref={this.imageRef}
                     src={this.props.imageURL}
-                    alt={`Página de ${this.props.imageURL}`}
+                    alt={`Imagem da página ${this.props.pageIndex}`}
                     className={"pageImage"}
                     style={{
                         maxWidth: `${this.state.imageZoom}%`,
@@ -495,6 +524,23 @@ class LayoutImage extends React.Component {
                     onDragEnd={(e) => this.dragEnd(e)}
                     onLoad={() => this.loadBoxes()}
                 />
+                {/*
+                <canvas
+                    id="image-canvas"
+                    className={"pageImage"}
+                    style={{
+                        maxWidth: `${this.state.imageZoom}%`,
+                        maxHeight: `${this.state.imageZoom}%`,
+                    }}
+                    onDragStart={(e) => {
+                        e.dataTransfer.setDragImage(transparentPixel, 0, 0);
+                        this.dragStart(e);
+                    }}
+                    onDragOver={(e) => this.duringDrag(e)}
+                    onDragEnd={(e) => this.dragEnd(e)}
+                    onLoad={() => this.loadBoxes()}
+                />
+                */}
 
                 {
                     this.state.boxes.map((box) => {


### PR DESCRIPTION
TIFF images are not generally rendered by most browsers. As a result, for documents consisting of TIFF images, the interface for editing OCR results does not allow a visual comparison of the page to the obtained text, and the interface for setting layout boxes is entirely unusable.

This PR uses a JavaScript package to automatically decode TIFF files and render them, given some delay for the conversion to take place. The sizes of the images is the same, ensuring that selected layout areas and result words are registered and displayed with the correct coordinates.