### PR TITLE
Load image once to OCR all text boxes when using tesserOCR

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -856,11 +856,11 @@ def request_ocr():
 
         for page in pages:
             page_id = generate_uuid(page.path)
-            log.warning(f"Removing {page.path}: ID={page_id}")
+            log.debug(f"Removing {page.path}: ID={page_id}")
             try:
                 es.delete_document(page_id)
             except NotFoundError:
-                log.warning(f"Failed to find {page.path}: ID={page_id}")
+                log.debug(f"Failed to find {page.path}: ID={page_id}")
                 continue
 
         # Delete previous results
@@ -944,8 +944,6 @@ def index_doc():
             )
 
         page_id = generate_uuid(page.path)
-        log.warning(f"Doc gerado: {page.path}: ID={page_id}, {doc}")
-
         es.add_document(page_id, doc)
 
     update_json_file(data_path, {"indexed": True})
@@ -977,7 +975,6 @@ def remove_index_doc():
     try:
         for page in pages:
             page_id = generate_uuid(page.path)
-            log.warning(f"Apagando {page.path}: ID={page_id}")
             es.delete_document(page_id)
 
         update_json_file(data_path, {"indexed": False})

--- a/server/app.py
+++ b/server/app.py
@@ -854,14 +854,15 @@ def request_ocr():
             if os.path.splitext(f.name)[1] == ".json"
         ]
 
-        for page in pages:
-            page_id = generate_uuid(page.path)
-            log.debug(f"Removing {page.path}: ID={page_id}")
-            try:
-                es.delete_document(page_id)
-            except NotFoundError:
-                log.debug(f"Failed to find {page.path}: ID={page_id}")
-                continue
+        if data["indexed"]:
+            for page in pages:
+                page_id = generate_uuid(page.path)
+                log.debug(f"Removing {page.path}: ID={page_id}")
+                try:
+                    es.delete_document(page_id)
+                except NotFoundError:
+                    log.debug(f"Failed to find {page.path}: ID={page_id}")
+                    continue
 
         # Delete previous results
         if os.path.exists(results_path):

--- a/server/celery_app.py
+++ b/server/celery_app.py
@@ -671,16 +671,26 @@ def task_page_ocr(
                     box_coordinates_list.append(box_coords)
 
             all_jsons = []
-            for box in box_coordinates_list:
-                # Perform OCR
-                # ocr_start = time.time()
-                json_d, _ = ocr_engine.get_structure(
-                    page=image, lang=lang, config=config, doc_path=path, segment_box=box
+            if ocr_engine_name.lower() == "ocr_tesserocr":
+                # TesserOCR can load an image once and OCR multiple segments within it.
+                all_jsons, _ = ocr_engine.get_structure(
+                    page=image,
+                    lang=lang,
+                    config=config,
+                    doc_path=path,
+                    segment_box=box_coordinates_list,
                 )
-                # ocr_time = time.time() - ocr_start
-                # page_metrics["ocr_time"] = ocr_time
-                if json_d:
-                    all_jsons.append(json_d)
+            else:
+                for box in box_coordinates_list:
+                    json_d, _ = ocr_engine.get_structure(
+                        page=image,
+                        lang=lang,
+                        config=config,
+                        doc_path=path,
+                        segment_box=box,
+                    )
+                    if json_d:
+                        all_jsons.append(json_d)
 
             page_json = []
             for sublist in all_jsons:

--- a/server/src/utils/parse_hocr.py
+++ b/server/src/utils/parse_hocr.py
@@ -1,16 +1,14 @@
 import re
-from lxml import etree
-from lxml import html
 
 p1 = re.compile(r"bbox((\s+\d+){4})")
 p2 = re.compile(r"baseline((\s+[\d\.\-]+){2})")
 
 
+"""
 def is_left(point_a, point_b, point_c):
     dx = 5
     return ((point_b[0] + dx) - (point_a[0] + dx)) * (point_c[1] - point_a[1]) - (point_b[1] - point_a[1]) * (
             point_c[0] - (point_a[0] + dx)) >= 0
-
 
 def remove_extra_paragraphs(lines):
     new_lines = [lines[0]]
@@ -29,6 +27,7 @@ def remove_extra_paragraphs(lines):
                 new_lines.append(lines[i])
 
     return new_lines
+"""
 
 
 def parse_hocr(hocr, segment_box):
@@ -75,8 +74,9 @@ def parse_hocr(hocr, segment_box):
         if words:
             lines.append(words)
 
-    if segment_box and lines:
-        lines = remove_extra_paragraphs(lines)
+    # Turns segment into a single line. Not needed(?)
+    # if segment_box and lines:
+    #     lines = remove_extra_paragraphs(lines)
 
     return lines
 


### PR DESCRIPTION
TesserOCR can initialize Tesseract once, load an image once with SetImage(), and then use SetRectangle() several times to select and process multiple areas within the loaded image. With these changes, this optimisation is leveraged for pages that have several boxes.

In a first test using a 19-page PDF file with 0 to 18 text boxes selected per page, averaging 7.8 boxes per page, the statistics for the runtimes of all page-processing tasks were (in seconds):
- PyTesseract (always initialises engine): 
    - sum: `69.80`
    - average: `3.674`
    - median: `2.7`
    - fastest: `1.14`
    - slowest: `6.29`
- TesserOCR **without** multiple SetRectangle() after single engine init:
    - sum: `280.18`
    - average: `14.746`
    - median: `12.79`
    - fastest: `2.49`
    - slowest: `36.87`
- TesserOCR **with** multiple SetRectangle() after single engine init:
    - sum: `59.94` !
    - average: `3.155` !
    - median: `2.8`
    - fastest: `1.74`
    - slowest: `5.36` !

This PR also generalises the implementation of `task_page_ocr()` to remove code that is duplicated due to branching for single- or multi-page documents; fixes an undesirable processing step of hOCR results obtained from segments, which combined all lines of the segment into a single line; and adds a check to only attempt to remove a document's pages from the elasticsearch index at the start of OCR if the document is tagged as indexed in its data JSON.