### PR TITLE
Split multi-page TIFF files to allow processing all pages

### DIFF
--- a/server/celery_app.py
+++ b/server/celery_app.py
@@ -207,21 +207,44 @@ def task_prepare_file_ocr(path: str, callback: Signature | None = None):
                     f"{path}/_pages/{basename}_{i}.png", format="PNG"
                 )  # using PNG to keep RGBA
             shutil.rmtree(temp_folder_name)
-            task_count_doc_pages(path=path, extension=extension)
-            if callback is not None:
-                callback.apply_async()
+
+        elif extension == "tif" or extension == "tiff":
+            img = Image.open(f"{path}/{basename}.{extension}", formats=["tiff"])
+            n_frames = img.n_frames
+            if n_frames == 1:
+                original_path = f"{path}/{basename}.{extension}"
+                link_path = f"{path}/_pages/{basename}_0.{extension}"
+                if not os.path.exists(link_path):
+                    os.link(original_path, link_path)
+            else:
+                compression = img._compression
+                log.warning(f"TIFF with {n_frames} frames, compression {compression}")
+                img.save(
+                    f"{path}/_pages/{basename}_0.{extension}",
+                    save_all=False,
+                    compression=compression,
+                )
+
+                for i in range(1, n_frames):
+                    img.seek(i)
+                    img.save(
+                        f"{path}/_pages/{basename}_{i}.{extension}",
+                        save_all=False,
+                        compression=compression,
+                    )
 
         elif extension in ALLOWED_EXTENSIONS:  # some other than pdf
             original_path = f"{path}/{basename}.{extension}"
             link_path = f"{path}/_pages/{basename}_0.{extension}"
             if not os.path.exists(link_path):
                 os.link(original_path, link_path)
-            task_count_doc_pages(path=path, extension=extension)
-            if callback is not None:
-                callback.apply_async()
 
         else:
             raise FileNotFoundError("No file with a valid extension was found")
+
+        task_count_doc_pages(path=path, extension=extension)
+        if callback is not None:
+            callback.apply_async()
 
     except Exception as e:
         data_folder = f"{path}/_data.json"

--- a/server/celery_app.py
+++ b/server/celery_app.py
@@ -158,7 +158,6 @@ def task_perform_direct_ocr(
 @celery.task(name="prepare_file")
 def task_prepare_file_ocr(path: str, callback: Signature | None = None):
     try:
-        log.debug(f"Creating {path}/_pages")
         if not os.path.exists(f"{path}/_pages"):
             os.mkdir(f"{path}/_pages")
 
@@ -166,11 +165,6 @@ def task_prepare_file_ocr(path: str, callback: Signature | None = None):
         extension = data["extension"]
 
         basename = get_file_basename(path)
-
-        log.debug(f"Path: {path}")
-        log.debug(f"Extensao: {extension}")
-        log.debug(f"Basename: {basename}")
-        log.debug(f"{path}: A preparar páginas")
 
         if extension == "pdf":
             pdf = pdfium.PdfDocument(f"{path}/{basename}.pdf")
@@ -208,7 +202,7 @@ def task_prepare_file_ocr(path: str, callback: Signature | None = None):
                 )  # using PNG to keep RGBA
             shutil.rmtree(temp_folder_name)
 
-        elif extension == "tif" or extension == "tiff":
+        elif extension in ("tif", "tiff"):
             img = Image.open(f"{path}/{basename}.{extension}", formats=["tiff"])
             n_frames = img.n_frames
             if n_frames == 1:
@@ -218,7 +212,6 @@ def task_prepare_file_ocr(path: str, callback: Signature | None = None):
                     os.link(original_path, link_path)
             else:
                 compression = img._compression
-                log.warning(f"TIFF with {n_frames} frames, compression {compression}")
                 img.save(
                     f"{path}/_pages/{basename}_0.{extension}",
                     save_all=False,

--- a/server/src/utils/file.py
+++ b/server/src/utils/file.py
@@ -452,7 +452,7 @@ def get_page_count(target_path, extension):
     """
     Get the number of pages of a file
     """
-    if extension == "pdf" or extension == "zip":
+    if extension in ("pdf", "zip", "tif", "tiff"):
         return len(os.listdir(f"{target_path}/_pages"))
     elif extension in ALLOWED_EXTENSIONS:  # some other than pdf or zip
         return 1


### PR DESCRIPTION
See #266. Considering that the TIFF format is expected in the use case of high-quality scans of physical documents, supporting multi-frame files of this format should be a priority. The changes in this PR extract each frame of an uploaded TIFF into separate files which are stored in `_pages` and can be processed individually.