### PR TITLE
Reimplement auto-segmentation at block level with tesserOCR

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -1171,8 +1171,13 @@ def generate_automatic_layouts():
     path, is_private = format_path(request.values)
     if path is None:
         abort(HTTPStatus.NOT_FOUND)
+    use_hdbscan = False
+    if "use_hdbscan" in request.values:
+        use_hdbscan = request.values["use_hdbscan"] in ("true", "True")
     try:
-        celery.send_task("auto_segment", kwargs={"path": path}).get()
+        celery.send_task(
+            "auto_segment", kwargs={"path": path, "use_hdbscan": use_hdbscan}
+        ).get()
         layouts = get_file_layouts(path, is_private)
     except FileNotFoundError:
         abort(HTTPStatus.NOT_FOUND)

--- a/server/celery_app.py
+++ b/server/celery_app.py
@@ -42,8 +42,7 @@ from src.utils.file import save_file_layouts
 from src.utils.file import size_to_units
 from src.utils.file import TIMEZONE
 from src.utils.file import update_json_file
-
-# from src.utils.image import parse_images
+from src.utils.image import parse_images
 
 OCR_ENGINES = (
     "pytesseract",
@@ -76,8 +75,9 @@ load_invisible_font()
 
 
 @celery.task(name="auto_segment", priority=0)
-def task_auto_segment(path):
-    # return parse_images(path)
+def task_auto_segment(path, use_hdbscan=False):
+    if use_hdbscan:
+        return parse_images(path)
     pages_path = f"{path}/_pages"
     if not os.path.exists(pages_path):
         log.error(f"Error in parsing images at {path}: missing /_pages")


### PR DESCRIPTION
Replace the current hdbscan auto-segmentation with TesserOCR's segment detection, which produces significantly better results.

The hdbscan implementation remains accessible to allow comparison testing.