### PR TITLE
Await for end of results export before making list of results available

### DIFF
--- a/server/celery_app.py
+++ b/server/celery_app.py
@@ -848,8 +848,8 @@ def task_export_results(path: str, output_types: list[str]):
             else:
                 data["ner"] = {"complete": False, "error": True}
 
+        data["ocr"]["progress"] = "completed"
         update_json_file(data_file, data)
-        # return {"status": "success", "metricas": page_metrics}
         return {"status": "success"}
     except Exception as e:
         traceback.print_exc()

--- a/website/src/Components/FileSystem/Geral/DocumentRow.js
+++ b/website/src/Components/FileSystem/Geral/DocumentRow.js
@@ -83,7 +83,7 @@ class DocumentRow extends React.Component {
     }
 
     render() {
-        const buttonsDisabled = !(this.state.info["ocr"] === undefined || this.state.info["ocr"]["progress"] >= this.state.info["pages"])
+        const buttonsDisabled = !(this.state.info["ocr"] === undefined || this.state.info["ocr"]["progress"] === "completed")
         const usingCustomConfig = this.state.info?.["config"] && this.state.info["config"] !== "default";
         return (
             <>
@@ -229,7 +229,7 @@ class DocumentRow extends React.Component {
                                         </Box>
                                     </TableCell>
 
-                                : this.state.info["ocr"]["progress"] >= this.state.info["pages"]
+                                : this.state.info["ocr"]["progress"] === "completed"
                                     ? <TableCell className="explorerCell stateCell successCell" align='center'>
                                         <Box className="stateBox">
                                           <span>OCR concluído</span>
@@ -240,6 +240,16 @@ class DocumentRow extends React.Component {
                                     ? <TableCell className="explorerCell stateCell errorCell" align='center'>
                                         <Box className="stateBox">
                                           <span>Erro ao fazer OCR</span>
+                                        </Box>
+                                    </TableCell>
+
+                                : this.state.info["ocr"]["progress"] === this.state.info["pages"]
+                                    ? <TableCell className="explorerCell stateCell infoCell" align='center'>
+                                        <Box className="stateBox">
+                                          <span style={{textAlign: "left"}}>
+                                              A exportar resultados
+                                              <CircularProgress sx={{ml: '1rem'}} size='1rem' />
+                                          </span>
                                         </Box>
                                     </TableCell>
 


### PR DESCRIPTION
OCR is being shown as concluded before result files are fully exported, which allows the user to click the document prematurely and see only the original file available for download.

With this PR, the client interface displays a new status after OCR is completed, while result files are being produced. The export function updates the "progress" status to "completed", after which the list of results available for download is accessible.