### PR TITLE
Fix upload problems

### DIFF
--- a/compose/nginx/nginx.conf.template
+++ b/compose/nginx/nginx.conf.template
@@ -18,6 +18,7 @@ http {
 
     server {
         include /etc/nginx/mime.types;
+        client_max_body_size  2M;
 
         listen 80;
         # Use this instead to serve HTTPS:
@@ -49,6 +50,25 @@ http {
             proxy_connect_timeout 1800;
             proxy_send_timeout    1800;
             send_timeout          1800;
+        }
+
+        # Set a higher max body size for the upload route
+        location /api/upload-file {
+            proxy_pass            http://server:5001/upload-file;
+            proxy_read_timeout    1800;
+            proxy_connect_timeout 1800;
+            proxy_send_timeout    1800;
+            send_timeout          1800;
+            client_max_body_size  $CLIENT_MAX_BODY_SIZE;
+        }
+
+        # Set a higher max body size for the API upload-and-OCR route
+        location /api/perform-ocr {
+            proxy_pass            http://server:5001/perform-ocr;
+            proxy_read_timeout    1800;
+            proxy_connect_timeout 1800;
+            proxy_send_timeout    1800;
+            send_timeout          1800;
             client_max_body_size  $CLIENT_MAX_BODY_SIZE;
         }
 
@@ -60,7 +80,6 @@ http {
             proxy_connect_timeout 1800;
             proxy_send_timeout    1800;
             send_timeout          1800;
-            client_max_body_size  $CLIENT_MAX_BODY_SIZE;
         }
 
         # Don't serve Flower as an API endpoint: it's a browser tool
@@ -75,7 +94,6 @@ http {
             proxy_connect_timeout 1800;
             proxy_send_timeout    1800;
             send_timeout          1800;
-            client_max_body_size  $CLIENT_MAX_BODY_SIZE;
         }
 
         location /images/ {

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -110,7 +110,7 @@ services:
       - files_data:/usr/share/nginx/html/files
     environment:
       NGINX_ENVSUBST_OUTPUT_DIR: /etc/nginx
-      CLIENT_MAX_BODY_SIZE: 200M
+      CLIENT_MAX_BODY_SIZE: 2G
     restart: unless-stopped
     networks:
       - internal-network

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -110,7 +110,7 @@ services:
       - files_data:/usr/share/nginx/html/files
     environment:
       NGINX_ENVSUBST_OUTPUT_DIR: /etc/nginx
-      CLIENT_MAX_BODY_SIZE: 200M
+      CLIENT_MAX_BODY_SIZE: 2G
       NODE_ENV: development
     restart: unless-stopped
     networks:

--- a/server/app.py
+++ b/server/app.py
@@ -641,6 +641,7 @@ def prepare_upload():
                 "type": "file",
                 "extension": extension if extension in ALLOWED_EXTENSIONS else "other",
                 "stored": 0.00,
+                "creation": get_current_time(),
             },
             f,
             indent=2,

--- a/server/celery_app.py
+++ b/server/celery_app.py
@@ -140,7 +140,6 @@ def task_count_doc_pages(path: str, extension: str):
         {
             "pages": get_page_count(path, extension),
             "stored": True,
-            "creation": get_current_time(),
         },
     )
 

--- a/website/src/App.js
+++ b/website/src/App.js
@@ -367,10 +367,10 @@ function App() {
                                         && !this.state.currentFileName
                                         && (this.state.currentFolderPathList.length > 1 || Boolean(this.getPrivateSession())))
                                         ? <Button
-                                            variant="text"
+                                            variant="contained"
                                             startIcon={<NoteAddIcon/>}
                                             onClick={() => this.fileSystem.current.createFile()}
-                                            className="pathElement"
+                                            className="menuButton pathElement"
                                         >
                                             Adicionar Documento
                                         </Button>

--- a/website/src/Components/Form/Geral/PrivateSessionMenu.js
+++ b/website/src/Components/Form/Geral/PrivateSessionMenu.js
@@ -52,7 +52,7 @@ class PrivateSessionMenu extends React.Component {
         this.setState({ open: !this.state.open });
     }
 
-    createPrivateSession() {
+    uploadFile() {
         this.setState({ buttonDisabled: true, open: false });
         this.props.createFile();
     }
@@ -96,7 +96,7 @@ class PrivateSessionMenu extends React.Component {
                                 disabled={this.checkHasFile()}
                                 variant="contained"
                                 sx={{border: '1px solid black'}}
-                                onClick={() => this.createPrivateSession()}
+                                onClick={() => this.uploadFile()}
                             >
                                 Adicionar documento
                             </Button>


### PR DESCRIPTION
Checking for upload status is currently complex and not asynchronous, updating the status after a certain number of chunks are sent, and causing "state.info is undefined" errors due to seeking the filesystem info which is no longer included in the server response. With this PR the upload status is now checked asynchronously every 5 seconds while the uploaded file is not fully stored, and no longer causes errors.

This PR also changes the NGINX settings to now generally limit client_max_body_size to a generous 2MB, and reserve a higher limit for the two endpoints which can receive large user-uploaded files. For these, the limits have been increased in docker-compose files from 200MB to 2GB, as small chunk sizes simply increased network traffic. The browser client splits file into chunks of 1GB size. This now ensures the vast majority of use cases only require one or two requests to `/upload-file`, reducing the risk of users interrupting the upload process.

For simplification, and due to no evident difference in performance, updates to state.info no longer try to limit themselves to the rows corresponding to files being uploaded. All the data is simply updated more frequently while files are being uploaded.

Stuck uploads are also not registering due to being based on the document's "creation" field, which is set only after the end of preparation for OCR. With this PR, it is set on `prepare-upload()`. The check for stuck uploads is performed on page load to avoid being dependent on a user keeping the website open for longer than the check period.

The upload button is also restyled to highlight its importance to users.