### PR TITLE
Set fixed filesystem table height and allow scroll with sticky header

### DIFF
--- a/website/src/App.css
+++ b/website/src/App.css
@@ -180,6 +180,10 @@ cannot be styled with props, interferes with functioning of Autocomplete
   File Explorer table formatting
 */
 
+.MuiTableRow-head.explorerHeaderRow {
+    background-color: #f5f5f5;
+}
+
 .MuiTableRow-root.explorerRow {
     height: 4rem;
     background-color: #ffffff;
@@ -206,6 +210,7 @@ cannot be styled with props, interferes with functioning of Autocomplete
 }
 
 .MuiTableCell-root.explorerCell {
+    background-color: inherit;
     border-left: 1px solid #aaa;
     font-size: 1rem;
 }

--- a/website/src/Components/FileSystem/FileSystem.js
+++ b/website/src/Components/FileSystem/FileSystem.js
@@ -850,10 +850,14 @@ class FileExplorer extends React.Component {
 
     generateTable() {
         return (
-            <TableContainer component={Paper}>
-                <Table aria-label="filesystem table" sx={{tableLayout: "fixed", border:"1px solid #aaa"}}>
+            <TableContainer sx={{width: "100%", maxHeight: '71vh', border: '1px solid #aaa'}} component={Paper}>
+                <Table
+                    stickyHeader
+                    aria-label="filesystem table"
+                    sx={{tableLayout: "fixed", border:"1px solid #aaa", borderCollapse: "collapse"}}
+                >
                     <TableHead>
-                        <TableRow sx={{backgroundColor: "#f5f5f5"}}>
+                        <TableRow className="explorerHeaderRow">
                             <TableCell scope="column" className="explorerCell optionsCell" />
 
                             <TableCell


### PR DESCRIPTION
This PR sets a fixed height for the filesystem table, which keeps the footer on screen and allows the table to be scrolled down while keeping the header visible.