### PR TITLE
Disable Search feature and ElasticSearch container

### DIFF
--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -1,5 +1,6 @@
 volumes:
-  elasticsearch_data: {}
+  # FIXME: uncomment when searching feature is improved and re-enabled
+  # elasticsearch_data: {}
   files_data: {}
   configs_data: {}
 
@@ -20,9 +21,10 @@ services:
     expose:
       - "5001"  # exposed only to other services
     depends_on:
-      elasticsearch:
-        condition: service_healthy
-        restart: true
+      # FIXME: uncomment when searching feature is improved and re-enabled
+      # elasticsearch:
+      #   condition: service_healthy
+      #   restart: true
       redis:
         condition: service_healthy
         restart: true
@@ -116,26 +118,27 @@ services:
       - internal-network
       - external-network
 
-  elasticsearch:
-    build:
-      context: ./compose/elasticsearch
-      dockerfile: Dockerfile
-    expose:
-      - "9200"  # exposed only to other services
-    volumes:
-      - elasticsearch_data:/usr/share/elasticsearch/data
-    environment:
-      xpack.security.enabled: false
-      discovery.type: single-node
-    healthcheck:
-      test: curl --write-out 'HTTP %{http_code}' --fail --silent --output /dev/null http://localhost:9200
-      interval: 10s
-      timeout: 30s
-      retries: 15
-      start_period: 10s
-    restart: unless-stopped
-    networks:
-      - internal-network
+# FIXME: uncomment when searching feature is improved and re-enabled
+#  elasticsearch:
+#    build:
+#      context: ./compose/elasticsearch
+#      dockerfile: Dockerfile
+#    expose:
+#      - "9200"  # exposed only to other services
+#    volumes:
+#      - elasticsearch_data:/usr/share/elasticsearch/data
+#    environment:
+#      xpack.security.enabled: false
+#      discovery.type: single-node
+#    healthcheck:
+#      test: curl --write-out 'HTTP %{http_code}' --fail --silent --output /dev/null http://localhost:9200
+#      interval: 10s
+#      timeout: 30s
+#      retries: 15
+#      start_period: 10s
+#    restart: unless-stopped
+#    networks:
+#      - internal-network
 
 networks:
   internal-network:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,6 @@
 volumes:
-  elasticsearch_data: {}
+  # FIXME: uncomment when searching feature is improved and re-enabled
+  # elasticsearch_data: {}
   files_data: {}
   configs_data: {}
 
@@ -20,9 +21,10 @@ services:
     expose:
       - "5001"  # exposed only to other services
     depends_on:
-      elasticsearch:
-        condition: service_healthy
-        restart: true
+      # FIXME: uncomment when searching feature is improved and re-enabled
+      # elasticsearch:
+      #   condition: service_healthy
+      #   restart: true
       redis:
         condition: service_healthy
         restart: true
@@ -117,26 +119,27 @@ services:
       - internal-network
       - external-network
 
-  elasticsearch:
-    build:
-      context: ./compose/elasticsearch
-      dockerfile: Dockerfile
-    expose:
-      - "9200"  # exposed only to other services
-    volumes:
-      - elasticsearch_data:/usr/share/elasticsearch/data
-    environment:
-      xpack.security.enabled: false
-      discovery.type: single-node
-    healthcheck:
-      test: curl --write-out 'HTTP %{http_code}' --fail --silent --output /dev/null http://localhost:9200
-      interval: 10s
-      timeout: 30s
-      retries: 15
-      start_period: 10s
-    restart: unless-stopped
-    networks:
-      - internal-network
+# FIXME: uncomment when searching feature is improved and re-enabled
+#  elasticsearch:
+#    build:
+#      context: ./compose/elasticsearch
+#      dockerfile: Dockerfile
+#    expose:
+#      - "9200"  # exposed only to other services
+#    volumes:
+#      - elasticsearch_data:/usr/share/elasticsearch/data
+#    environment:
+#      xpack.security.enabled: false
+#      discovery.type: single-node
+#    healthcheck:
+#      test: curl --write-out 'HTTP %{http_code}' --fail --silent --output /dev/null http://localhost:9200
+#      interval: 10s
+#      timeout: 30s
+#      retries: 15
+#      start_period: 10s
+#    restart: unless-stopped
+#    networks:
+#      - internal-network
 
 networks:
   internal-network:

--- a/server/app.py
+++ b/server/app.py
@@ -15,7 +15,6 @@ from celery import Celery
 from celery.schedules import crontab
 from celery.schedules import schedule
 from dotenv import load_dotenv
-from elasticsearch import NotFoundError
 from flask import abort
 from flask import Flask
 from flask import g
@@ -36,12 +35,6 @@ from flask_security.models import fsqla_v3 as fsqla
 from flask_sqlalchemy import SQLAlchemy
 from redbeat import RedBeatSchedulerEntry
 from redbeat.schedulers import RedBeatConfig
-from src.elastic_search import create_document
-from src.elastic_search import ElasticSearchClient
-from src.elastic_search import ES_INDEX
-from src.elastic_search import ES_URL
-from src.elastic_search import mapping
-from src.elastic_search import settings
 from src.utils.file import ALLOWED_EXTENSIONS
 from src.utils.file import API_TEMP_PATH
 from src.utils.file import delete_structure
@@ -67,6 +60,15 @@ from src.utils.system import get_size_api_files
 from src.utils.system import get_size_private_spaces
 from src.utils.text import compare_dicts_words
 from werkzeug.utils import safe_join
+
+# FIXME: uncomment when searching feature is improved and re-enabled
+# from elasticsearch import NotFoundError
+# from src.elastic_search import create_document
+# from src.elastic_search import ElasticSearchClient
+# from src.elastic_search import ES_INDEX
+# from src.elastic_search import ES_URL
+# from src.elastic_search import mapping
+# from src.elastic_search import settings
 
 # from src.utils.system import get_logs
 
@@ -122,7 +124,9 @@ security = Security(app, user_datastore)
 celery = Celery("celery_app", backend=CELERY_RESULT_BACKEND, broker=CELERY_BROKER_URL)
 
 # Setup connection to ElasticSearch
-es = ElasticSearchClient(ES_URL, ES_INDEX, mapping, settings)
+# FIXME: uncomment when searching feature is improved and re-enabled
+# es = ElasticSearchClient(ES_URL, ES_INDEX, mapping, settings)
+
 # logging.basicConfig(filename="record.log", level=logging.DEBUG, format=f'%(asctime)s %(levelname)s : %(message)s')
 
 log = app.logger
@@ -527,7 +531,8 @@ def delete_path():
         ):
             abort(HTTPStatus.NOT_FOUND)
 
-        delete_structure(es, path)
+        # FIXME: uncomment when searching feature is improved and re-enabled
+        # delete_structure(es, path)
         shutil.rmtree(path)
     except FileNotFoundError:
         abort(HTTPStatus.NOT_FOUND)
@@ -857,6 +862,9 @@ def request_ocr():
 
         # Remove indexed pages, which will become outdated
         results_path = f"{f}/_ocr_results"
+
+        # FIXME: uncomment when searching feature is improved and re-enabled
+        """
         pages = [
             f
             for f in os.scandir(results_path)
@@ -870,6 +878,7 @@ def request_ocr():
                     es.delete_document(page_id)
                 except NotFoundError:
                     continue
+        """
 
         # Delete previous results
         if os.path.exists(results_path):
@@ -913,13 +922,11 @@ def request_ocr():
     }
 
 
+# FIXME: uncomment when searching feature is improved and re-enabled
+"""
 @app.route("/index-doc", methods=["POST"])
 @requires_json_path
 def index_doc():
-    """
-    Index a document in Elasticsearch
-    @param path: path to the document
-    """
     data = request.json
     path, _ = format_path(data)
     if path is None:
@@ -971,10 +978,6 @@ def index_doc():
 @app.route("/remove-index-doc", methods=["POST"])
 @requires_json_path
 def remove_index_doc():
-    """
-    Remove a document in Elasticsearch
-    @param path: path to the document
-    """
     data = request.json
     path, _ = format_path(data)
     if path is None:
@@ -1003,6 +1006,7 @@ def remove_index_doc():
             "success": False,
             "message": "O documento não foi encontrado no index.",
         }
+"""
 
 
 @app.route("/submit-text", methods=["POST"])
@@ -1070,6 +1074,9 @@ def check_sintax():
 #####################################
 # ELASTICSEARCH
 #####################################
+
+# FIXME: uncomment when searching feature is improved and re-enabled
+"""
 @app.route("/get-docs-list", methods=["GET"])
 def get_docs_list():
     return es.get_all_docs_names()
@@ -1092,6 +1099,7 @@ def search():
         return jsonify(es.get_docs(docs))
     else:
         return jsonify(es.search(query, docs))
+"""
 
 
 #####################################

--- a/website/src/App.js
+++ b/website/src/App.js
@@ -362,7 +362,7 @@ function App() {
                         </Box>
 
                         <Box sx={{display: "flex", flexDirection: "row", lineHeight: "2rem"}}>
-                            {buttonsDisabled || Boolean(this.getPrivateSpaceId())
+                            {true || buttonsDisabled || Boolean(this.getPrivateSpaceId())  // FIXME: Remove "true ||" to re-enable indexing
                                 ? null
                                 : <Button
                                     variant="contained"

--- a/website/src/Components/FileSystem/DocumentRow.js
+++ b/website/src/Components/FileSystem/DocumentRow.js
@@ -294,7 +294,7 @@ class DocumentRow extends React.Component {
                     </MenuItem>
 
                     {
-                        this.props._private
+                        true || this.props._private  // FIXME: Remove "true ||" to re-enable indexing
                             ? null
                             : (info?.["indexed"]
                                 ? <MenuItem


### PR DESCRIPTION
It has not been possible to adequately improve the indexing and search feature due to the higher priority of other features. The searching is still primitive and could be enhanced with additional options to search by OCR-related metadata, and the search page still presents usability problems. This PR disables the browser client components for indexing and searching and the ElasticSearch container, with the expectation that the feature will be developed in the future.

With the removal of the ElasticSearch container, the baseline memory occupied by the system is reduced from 9GB to about 770MB, which made evident that the cost in resource usage of this implementation of information retrieval may be disproportionately high for the value added to the system.