### PR TITLE
Allow altering max private space age in Storage Manager

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -1529,7 +1529,7 @@ def set_max_private_space_age():
             os.environ["MAX_PRIVATE_SPACE_AGE"] = str(int(new_max_age))
             return {
                 "success": True,
-                "message": f"New max private space age: {new_max_age} days",
+                "message": f"New max private space age: {new_max_age} day(s)",
             }
     except ValueError:
         return {

--- a/server/celery_app.py
+++ b/server/celery_app.py
@@ -1346,7 +1346,7 @@ def task_set_max_private_space_age(new_max_age: int | str):
 @celery.task(name="cleanup_private_spaces", priority=0)
 def task_delete_old_private_spaces():
     max_private_space_age = int(os.environ.get("MAX_PRIVATE_SPACE_AGE", "1"))  # days
-    log.info(f"Deleting private spaces older than {max_private_space_age} days")
+    log.info(f"Deleting private spaces older than {max_private_space_age} day(s)")
 
     private_spaces = [f.path for f in os.scandir(f"./{PRIVATE_PATH}/") if f.is_dir()]
     n_deleted = 0

--- a/website/src/Components/Admin/StorageManager.js
+++ b/website/src/Components/Admin/StorageManager.js
@@ -17,6 +17,7 @@ import { TimePicker } from "@mui/x-date-pickers/TimePicker";
 
 import ReturnButton from 'Components/FileSystem/ReturnButton';
 import Notification from 'Components/Notifications/Notification';
+import ChangeMaxAgePopup from 'Components/Form/ChangeMaxAgePopup';
 import ConfirmActionPopup from 'Components/Form/ConfirmActionPopup';
 import CheckboxList from 'Components/Form/CheckboxList';
 import TooltipIcon from 'Components/TooltipIcon/TooltipIcon';
@@ -56,7 +57,7 @@ const StorageManager = (props) => {
     const [privateSpaces, setPrivateSpaces] = useState([]);
     const [apiFiles, setApiFiles] = useState([]);
     const [lastCleanup, setLastCleanup] = useState("nunca");
-    const [maxPrivateSpaceAge, setMaxPrivateSpaceAge] = useState("5");
+    const [maxPrivateSpaceAge, setMaxPrivateSpaceAge] = useState("1");
 
     const [refreshing, setRefreshing] = useState(true);
     const [lastUpdate, setLastUpdate] = useState(null);
@@ -73,6 +74,8 @@ const StorageManager = (props) => {
 
     const [deleteSpaceId, setDeleteSpaceId] = useState(null);
     const [deleteApiDocumentId, setDeleteApiDocumentId] = useState(null);
+
+    const [changeMaxAgePopupOpened, setChangeMaxAgePopupOpened] = useState(false);
 
     const [confirmPopupOpened, setConfirmPopupOpened] = useState(false);
     const [confirmPopupMessage, setConfirmPopupMessage] = useState("");
@@ -231,10 +234,26 @@ const StorageManager = (props) => {
         // confirm popup is set up in useEffect
     }
 
+
+    function openChangeMaxAgePopup(e) {
+        e.stopPropagation();
+        setChangeMaxAgePopupOpened(true);
+    }
+
+    function closeChangeMaxAgePopup() {
+        setChangeMaxAgePopupOpened(false);
+    }
+
+    function submittedChangeMaxAge(newMaxAge, responseMessage) {
+        setChangeMaxAgePopupOpened(false);
+        setMaxPrivateSpaceAge(newMaxAge);
+        successNotif.current.openNotif(responseMessage);
+    }
+
     function openCleanupPopup(e) {
         e.stopPropagation();
         setConfirmPopupOpened(true);
-        setConfirmPopupMessage(`Tem a certeza que quer remover as sessões com mais de ${maxPrivateSpaceAge} dias?`);
+        setConfirmPopupMessage(`Tem a certeza que quer remover as sessões com mais de ${maxPrivateSpaceAge} dia(s)?`);
         setConfirmPopupSubmitCallback(() => runPrivateSpaceCleanup);  // set value as function runPrivateSpaceCleanup
     }
 
@@ -318,6 +337,13 @@ const StorageManager = (props) => {
             <Notification message={""} severity={"success"} ref={successNotif}/>
             <Notification message={""} severity={"error"} ref={errorNotif}/>
 
+            <ChangeMaxAgePopup
+                open={changeMaxAgePopupOpened}
+                maxAge={maxPrivateSpaceAge}
+                submitCallback={submittedChangeMaxAge}
+                cancelCallback={closeChangeMaxAgePopup}
+            />
+
             <ConfirmActionPopup
                 open={confirmPopupOpened}
                 message={confirmPopupMessage}
@@ -397,6 +423,24 @@ const StorageManager = (props) => {
                         Último update: {lastUpdate ? lastUpdate.toLocaleString("pt-PT") : "nunca"}
                     </span>
                 </Box>
+
+                <Box>
+                    <Button
+                        variant="contained"
+                        onClick={(e) => openCleanupPopup(e)}
+                        className="menuButton menuFunctionButton"
+                    >
+                        Remover espaços privados com mais de {maxPrivateSpaceAge} dia(s)
+                    </Button>
+
+                    <Button
+                        variant="contained"
+                        onClick={(e) => openChangeMaxAgePopup(e)}
+                        className="menuButton menuFunctionButton"
+                    >
+                        Alterar idade máxima
+                    </Button>
+                </Box>
             </Box>
 
             <Box sx={{
@@ -473,15 +517,6 @@ const StorageManager = (props) => {
                     width: 'fit-content',
                     alignItems: 'center',
                 }}>
-                    <Button
-                        variant="contained"
-                        onClick={(e) => openCleanupPopup(e)}
-                        className="menuButton"
-                        sx={{alignSelf: 'center'}}
-                    >
-                        Remover espaços privados com mais de {maxPrivateSpaceAge} dias
-                    </Button>
-
                     <Box sx = {{
                             display: "flex",
                             flexDirection: "column",

--- a/website/src/Components/Form/ChangeMaxAgePopup.js
+++ b/website/src/Components/Form/ChangeMaxAgePopup.js
@@ -1,0 +1,137 @@
+import React, {useCallback, useRef, useState} from "react";
+import axios from "axios";
+
+import Box from '@mui/material/Box';
+import TextField from "@mui/material/TextField";
+import Typography from '@mui/material/Typography';
+import Modal from '@mui/material/Modal';
+import Button from '@mui/material/Button';
+import IconButton from '@mui/material/IconButton';
+import CloseRoundedIcon from '@mui/icons-material/CloseRounded';
+import ClickAwayListener from "@mui/material/ClickAwayListener";
+
+import Notification from 'Components/Notifications/Notification';
+
+const style = {
+    position: 'absolute',
+    top: '50%',
+    left: '50%',
+    transform: 'translate(-50%, -50%)',
+    width: 'fit-content',
+    bgcolor: 'background.paper',
+    border: '2px solid #000',
+    boxShadow: 24,
+    p: 4,
+    borderRadius: 2
+};
+
+const crossStyle = {
+    position: 'absolute',
+    top: '0.5rem',
+    right: '0.5rem'
+}
+
+const API_URL = `${window.location.protocol}//${window.location.host}/${process.env.REACT_APP_API_URL}`;
+const numberDaysRegex = /^[1-9][0-9]*$/;
+
+function ChangeMaxAgePopup(
+    {
+        open = false,
+        maxAge = "1",
+        // functions:
+        submitCallback = null,  // required
+        cancelCallback = null,  // required
+    }) {
+    const successNotifRef = useRef(null);
+    const errorNotifRef = useRef(null);
+
+    const [newMaxAge, setNewMaxAge] = useState(maxAge);
+
+    function handleClickOutsideMenu() {
+        if (open) {
+            cancelCallback();
+        }
+    }
+
+    function handleAgeValueChange(value) {
+        value = value.trim();
+        if (!(numberDaysRegex.test(value)) && value !== '') {
+            errorNotifRef.current.openNotif("O número de dias deve ser um valor inteiro positivo!");
+        }
+        setNewMaxAge(value);
+    }
+
+    const sendMaxAgeChangeRequest = useCallback(() => {
+        axios.post(API_URL + "/admin/set-max-private-space-age",
+            {
+                "new_max_age": newMaxAge
+            },
+        )
+        .then(({ data }) => {
+            submitCallback(newMaxAge, data["message"]);
+        })
+        .catch(err => {
+            successNotifRef.current.openNotif(err.message);
+        });
+    }, [newMaxAge]);
+
+    return (
+        <Box>
+            <Notification message={""} severity={"success"} ref={successNotifRef}/>
+            <Notification message={""} severity={"error"} ref={errorNotifRef}/>
+            <Modal open={open}>
+                <ClickAwayListener
+                    mouseEvent="onMouseDown"
+                    touchEvent="onTouchStart"
+                    onClickAway={() => handleClickOutsideMenu()}
+                >
+                    <Box sx={style}>
+                        <Typography id="modal-modal-title" variant="h5" component="h2">
+                            Alterar idade máxima
+                        </Typography>
+
+                        <Box sx={{
+                            display: 'flex',
+                            flexDirection: 'row',
+                            alignItems: 'center',
+                        }}>
+                            <span>
+                                Idade máxima dos espaços privados (dias):
+                            </span>
+                            <TextField
+                                error={!(numberDaysRegex.test(newMaxAge))}
+                                value={newMaxAge}
+                                onChange={(e) => handleAgeValueChange(e.target.value)}
+                                hiddenLabel
+                                size="small"
+                                variant="outlined"
+                                className="simpleInput"
+                                sx={{
+                                    width: '4rem',
+                                    marginLeft: '0.3rem',
+                                    marginRight: '0.3rem',
+                                    textAlign: "center",
+                                }}
+                            />
+                        </Box>
+                        <Button
+                            disabled={!numberDaysRegex.test(newMaxAge)}
+                            color="success"
+                            variant="contained"
+                            sx={{border: '1px solid black', mt: '0.5rem'}}
+                            onClick={() => sendMaxAgeChangeRequest()}
+                        >
+                            Confirmar
+                        </Button>
+
+                        <IconButton sx={crossStyle} aria-label="close" onClick={() => cancelCallback()}>
+                            <CloseRoundedIcon />
+                        </IconButton>
+                    </Box>
+                </ClickAwayListener>
+            </Modal>
+        </Box>
+    );
+}
+
+export default ChangeMaxAgePopup;


### PR DESCRIPTION
An endpoint already existed to allow changing the maximum age of private spaces before they are deleted by the cleanup task. This PR exposes this functionality in the browser application with a new pop-up in the Storage Manager.

The columns of the different possible types of automated cleanup schedule are also reordered to follow the logic of most frequent on the left to least frequent on the right: day scope; week scope; month scope.