### PR TITLE
Fix calculation of length of PDF with index

### DIFF
--- a/server/celery_app.py
+++ b/server/celery_app.py
@@ -260,13 +260,17 @@ def task_make_changes(path, data):
             keep_temp=data["pdf"]["complete"],
             get_csv=recreate_csv,
         )
+
+        exported_pdf = pdfium.PdfDocument(
+            f"{path}/_export/_pdf_indexed.pdf", autoclose=True
+        )
         data["pdf_indexed"] = {
             "complete": True,
             "size": size_to_units(
                 get_file_size(export_folder + "/_pdf_indexed.pdf", path_complete=True)
             ),
             "creation": created_time,
-            "pages": get_page_count(path, "pdf") + 1,
+            "pages": len(exported_pdf),
         }
 
     if "pdf" in recreate_types:
@@ -1310,6 +1314,10 @@ def task_export_results(path: str, output_types: list[str]):
                 get_csv=("csv" in output_types),
             )
             creation_time = get_current_time()
+            exported_pdf = pdfium.PdfDocument(
+                f"{path}/_export/_pdf_indexed.pdf", autoclose=True
+            )
+
             data["pdf_indexed"] = {
                 "complete": True,
                 "size": size_to_units(
@@ -1318,7 +1326,7 @@ def task_export_results(path: str, output_types: list[str]):
                     )
                 ),
                 "creation": creation_time,
-                "pages": get_page_count(path, "pdf") + 1,
+                "pages": len(exported_pdf),
             }
             if "csv" in output_types:
                 # CSV exported as part of PDF export

--- a/server/celery_app.py
+++ b/server/celery_app.py
@@ -7,6 +7,7 @@ import tempfile
 import traceback
 import uuid
 import zipfile
+from contextlib import suppress
 from datetime import datetime
 from io import BytesIO
 
@@ -252,7 +253,8 @@ def task_make_changes(path, data):
             },
         )
         recreate_csv = "csv" in recreate_types
-        os.remove(export_folder + "/_pdf_indexed.pdf")
+        with suppress(FileNotFoundError):
+            os.remove(export_folder + "/_pdf_indexed.pdf")
         export_file(
             path,
             "pdf",
@@ -284,7 +286,8 @@ def task_make_changes(path, data):
             },
         )
         recreate_csv = "csv" in recreate_types and "pdf_indexed" not in recreate_types
-        os.remove(export_folder + "/_pdf.pdf")
+        with suppress(FileNotFoundError):
+            os.remove(export_folder + "/_pdf.pdf")
         export_file(
             path,
             "pdf",
@@ -921,7 +924,8 @@ def task_extract_pdf_page(path, basename, i):
             )
         except Exception as e:
             log.error(f"Invalid PNG generated for page {i}: {e}")
-            os.remove(output_path)  # Remove truncated file
+            with suppress(FileNotFoundError):
+                os.remove(output_path)  # Remove truncated file
             raise
 
         # Generate document thumbnails with first page

--- a/server/celery_app.py
+++ b/server/celery_app.py
@@ -266,6 +266,7 @@ def task_make_changes(path, data):
                 get_file_size(export_folder + "/_pdf_indexed.pdf", path_complete=True)
             ),
             "creation": created_time,
+            "pages": get_page_count(path, "pdf") + 1,
         }
 
     if "pdf" in recreate_types:
@@ -294,6 +295,7 @@ def task_make_changes(path, data):
                 get_file_size(export_folder + "/_pdf.pdf", path_complete=True)
             ),
             "creation": created_time,
+            "pages": get_page_count(path, "pdf"),
         }
 
     if (


### PR DESCRIPTION
Page counts of PDF outputs were being removed by the re-generation task after editing the results. This PR ensures they are recalculated (a change in word count may influence the length of the index in corner cases).

It also suppresses some FileNotFound errors when attempting to remove files in Celery tasks, as there is no problem if the target of removal is already absent.